### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 tbrand
+Copyright © 2017-2018 The SushiChain Core developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dapps/create_transaction.cr
+++ b/dapps/create_transaction.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::User
   class CreateTransaction < UserDApp
     #

--- a/dapps/dapp.cr
+++ b/dapps/dapp.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::User
   #
   # This is a super class of every user defined dApps.

--- a/dapps/dapps.cr
+++ b/dapps/dapps.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::User
   #
   # please add your dApps into the 'USER_DAPPS'

--- a/dapps/hello_world.cr
+++ b/dapps/hello_world.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 # An example for SushiChain's dApps
 #
 # - Hello World!

--- a/spec/e2e/client.cr
+++ b/spec/e2e/client.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "random"
 require "./utils"
 

--- a/spec/e2e/runner.cr
+++ b/spec/e2e/runner.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "random"
 require "file_utils"
 require "./utils"

--- a/spec/e2e/spec.cr
+++ b/spec/e2e/spec.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./runner"
 
 describe E2E do

--- a/spec/e2e/utils.cr
+++ b/spec/e2e/utils.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./utils/*"
 
 module ::E2E::Utils

--- a/spec/e2e/utils/api.cr
+++ b/spec/e2e/utils/api.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::E2E::Utils::API
   def sushi(args) : String
     _args = args

--- a/spec/e2e/utils/log.cr
+++ b/spec/e2e/utils/log.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::E2E::Utils::Log
   def log_path(num : Int32, is_miner : Bool = false) : String
     log_name = is_miner ? "#{num}_miner.log" : "#{num}.log"

--- a/spec/e2e/utils/miner.cr
+++ b/spec/e2e/utils/miner.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::E2E::Utils::Miner
   def sushim(args) : String
     _args = args

--- a/spec/e2e/utils/node.cr
+++ b/spec/e2e/utils/node.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::E2E::Utils::Node
   def sushid(args) : String
     _args = args

--- a/spec/e2e/utils/wallet.cr
+++ b/spec/e2e/utils/wallet.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::E2E::Utils::Wallet
   def wallet(num : Int32) : String
     File.expand_path("../../../../wallets/testnet-#{num}.json", __FILE__)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "spec"
 
 require "../src/common"

--- a/spec/sushi_spec.cr
+++ b/spec/sushi_spec.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./spec_helper"
 
 include ::Sushi::Common::Color

--- a/spec/units/blockchain/block.cr
+++ b/spec/units/blockchain/block.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/blockchain/consensus.cr
+++ b/spec/units/blockchain/consensus.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 
 include Sushi::Core

--- a/spec/units/blockchain/transaction.cr
+++ b/spec/units/blockchain/transaction.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/blockchain/wallet.cr
+++ b/spec/units/blockchain/wallet.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/blowfish/blowfish.cr
+++ b/spec/units/blowfish/blowfish.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/dapps/scars.cr
+++ b/spec/units/dapps/scars.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/dapps/utxo.cr
+++ b/spec/units/dapps/utxo.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/ecdsa/point.cr
+++ b/spec/units/ecdsa/point.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/ecdsa/secp256k1.cr
+++ b/spec/units/ecdsa/secp256k1.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/keys/address.cr
+++ b/spec/units/keys/address.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/keys/keys.cr
+++ b/spec/units/keys/keys.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/keys/private_key.cr
+++ b/spec/units/keys/private_key.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/keys/public_key.cr
+++ b/spec/units/keys/public_key.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/keys/wif.cr
+++ b/spec/units/keys/wif.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./../../spec_helper"
 require "./../utils"
 

--- a/spec/units/license_spec.cr
+++ b/spec/units/license_spec.cr
@@ -11,16 +11,15 @@
 # Removal or modification of this copyright notice is prohibited.
 
 require "./../../spec_helper"
-require "./../utils"
 
-include Sushi::Core
-include Sushi::Core::Keys
-
-describe BlowFish do
-  it "should encrypt and decrypt" do
-    encrypted = BlowFish.encrypt("password", "some-data")
-    decrypted = BlowFish.decrypt("password", encrypted[:data], encrypted[:salt])
-    decrypted.should eq("some-data")
+describe "License" do
+  it "should have a license at the top of every crystal file" do
+    Dir["**/*.cr"].reject { |f| f.starts_with?("lib") }.each do |file_path|
+      # if this fails uncomment the line below to see the failed file
+      # to fix: cd tools then crystal run add_license.cr
+      # puts "file: #{file_path}"
+      File.read_lines(file_path).first.should eq("# Copyright © 2017-2018 The SushiChain Core developers")
+    end
   end
-  STDERR.puts "< BlowFish"
+  STDERR.puts "< License"
 end

--- a/spec/units/node/rpc_controller.cr
+++ b/spec/units/node/rpc_controller.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 # require "./../../spec_helper"
 # require "./../utils"
 #

--- a/spec/units/units.cr
+++ b/spec/units/units.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./blockchain/*"
 require "./node/*"
 require "./ecdsa/*"

--- a/spec/units/units.cr
+++ b/spec/units/units.cr
@@ -11,7 +11,9 @@
 # Removal or modification of this copyright notice is prohibited.
 
 require "./blockchain/*"
+require "./blowfish/*"
 require "./node/*"
 require "./ecdsa/*"
 require "./keys/*"
 require "./dapps/*"
+require "./license_spec.cr"

--- a/spec/units/utils.cr
+++ b/spec/units/utils.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./utils/*"
 
 module ::Units::Utils

--- a/spec/units/utils/blocks.cr
+++ b/spec/units/utils/blocks.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Units::Utils::BlockHelper
   include Sushi::Core
 

--- a/spec/units/utils/chain_generator.cr
+++ b/spec/units/utils/chain_generator.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Units::Utils::ChainGenerator
   include Sushi::Core
   include Sushi::Core::Models

--- a/spec/units/utils/node.cr
+++ b/spec/units/utils/node.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Units::Utils::NodeHelper
   include Sushi::Core
 

--- a/spec/units/utils/transaction.cr
+++ b/spec/units/utils/transaction.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Units::Utils::TransactionHelper
   include Sushi::Core
 

--- a/spec/units/utils/wallets.cr
+++ b/spec/units/utils/wallets.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Units::Utils::WalletHelper
   include Sushi::Core
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "option_parser"
 require "file_utils"
 require "colorize"

--- a/src/cli/helps.cr
+++ b/src/cli/helps.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./helps/*"

--- a/src/cli/helps/helps.cr
+++ b/src/cli/helps/helps.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface
   module Helps
     HELP_WALLET_PATH                      = "please specify your wallet: -w [your_wallet.json]"

--- a/src/cli/modules.cr
+++ b/src/cli/modules.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./modules/*"

--- a/src/cli/modules/config_manager.cr
+++ b/src/cli/modules/config_manager.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface
   class ConfigManager
     alias Configurable = String | Int32 | Int64 | Bool | Nil

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface
   module GlobalOptionParser
     @connect_node : String?

--- a/src/cli/modules/logger.cr
+++ b/src/cli/modules/logger.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Logger
   def puts_info(_msg : String?)
     return unless msg = _msg

--- a/src/cli/sushi.cr
+++ b/src/cli/sushi.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "../cli"
 require "./sushi/*"
 

--- a/src/cli/sushi/blockchain.cr
+++ b/src/cli/sushi/blockchain.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Sushi
   class Blockchain < CLI
     def sub_actions

--- a/src/cli/sushi/config.cr
+++ b/src/cli/sushi/config.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Sushi
   class Config < CLI
     def sub_actions

--- a/src/cli/sushi/scars.cr
+++ b/src/cli/sushi/scars.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Sushi
   class Scars < CLI
     def sub_actions

--- a/src/cli/sushi/token.cr
+++ b/src/cli/sushi/token.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Sushi
   class Token < CLI
     def sub_actions

--- a/src/cli/sushi/transaction.cr
+++ b/src/cli/sushi/transaction.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Sushi
   class Transaction < CLI
     def sub_actions

--- a/src/cli/sushi/wallet.cr
+++ b/src/cli/sushi/wallet.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Interface::Sushi
   class Wallet < CLI
     def sub_actions

--- a/src/cli/sushid.cr
+++ b/src/cli/sushid.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "../cli"
 
 module ::Sushi::Interface::SushiD

--- a/src/cli/sushim.cr
+++ b/src/cli/sushim.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "../cli"
 
 module ::Sushi::Interface::SushiM

--- a/src/common.cr
+++ b/src/common.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "colorize"
 
 require "./common/*"

--- a/src/common/modules.cr
+++ b/src/common/modules.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./modules/*"

--- a/src/common/modules/color.cr
+++ b/src/common/modules/color.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Common::Color
   COLORS = %w(black red green yellow blue magenta cyan light_gray dark_gray light_red light_green light_yellow light_blue light_magenta light_cyan white)
 

--- a/src/core.cr
+++ b/src/core.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   CORE_VERSION = 1
 end

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./blockchain/consensus"
 require "./blockchain/*"
 require "./dapps"

--- a/src/core/blockchain/block.cr
+++ b/src/core/blockchain/block.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   class Block
     extend Hashes

--- a/src/core/blockchain/consensus.cr
+++ b/src/core/blockchain/consensus.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Consensus
   CONFIRMATION = 10
 

--- a/src/core/blockchain/transaction.cr
+++ b/src/core/blockchain/transaction.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   class Transaction
     MESSAGE_SIZE_LIMIT = 512

--- a/src/core/blockchain/wallet.cr
+++ b/src/core/blockchain/wallet.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   class WalletException < Exception
   end

--- a/src/core/dapps.cr
+++ b/src/core/dapps.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./*"
 require "./dapps/dapp"
 

--- a/src/core/dapps/build_in.cr
+++ b/src/core/dapps/build_in.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./build_in/*"
 
 module ::Sushi::Core::DApps::BuildIn

--- a/src/core/dapps/build_in/blockchain_info.cr
+++ b/src/core/dapps/build_in/blockchain_info.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class BlockchainInfo < DApp
     def setup

--- a/src/core/dapps/build_in/fees.cr
+++ b/src/core/dapps/build_in/fees.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class Fees < DApp
     def setup

--- a/src/core/dapps/build_in/indices.cr
+++ b/src/core/dapps/build_in/indices.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class Indices < DApp
     @indices : Array(Hash(String, Int64)) = Array(Hash(String, Int64)).new

--- a/src/core/dapps/build_in/rejects.cr
+++ b/src/core/dapps/build_in/rejects.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class Rejects < DApp
     @rejects : Hash(String, String) = Hash(String, String).new

--- a/src/core/dapps/build_in/scars.cr
+++ b/src/core/dapps/build_in/scars.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   #
   # SushiChain Address Resolution System

--- a/src/core/dapps/build_in/token.cr
+++ b/src/core/dapps/build_in/token.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class Token < DApp
     getter tokens : Array(String) = ["SHARI"]

--- a/src/core/dapps/build_in/transaction.cr
+++ b/src/core/dapps/build_in/transaction.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class TransactionCreator < DApp
     def setup

--- a/src/core/dapps/build_in/utxo.cr
+++ b/src/core/dapps/build_in/utxo.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps::BuildIn
   class UTXO < DApp
     DEFAULT = "SHARI"

--- a/src/core/dapps/dapp.cr
+++ b/src/core/dapps/dapp.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::DApps
   abstract class DApp
     abstract def setup

--- a/src/core/database.cr
+++ b/src/core/database.cr
@@ -1,2 +1,14 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "sqlite3"
 require "./database/database.cr"

--- a/src/core/database/database.cr
+++ b/src/core/database/database.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   class Database
     getter path : String

--- a/src/core/ecdsa.cr
+++ b/src/core/ecdsa.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::ECDSA
   def mod_inv(a : BigInt, mod : BigInt)
     lim, him = BigInt.new(1), BigInt.new(0)

--- a/src/core/ecdsa/group.cr
+++ b/src/core/ecdsa/group.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::ECDSA
   abstract class Group
     abstract def _gx : BigInt

--- a/src/core/ecdsa/point.cr
+++ b/src/core/ecdsa/point.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::ECDSA
   class Point
     getter x : BigInt

--- a/src/core/ecdsa/secp256k1.cr
+++ b/src/core/ecdsa/secp256k1.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::ECDSA
   class Secp256k1 < Group
     def _gx : BigInt

--- a/src/core/keys.cr
+++ b/src/core/keys.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Keys
   include Sushi::Core::Models
   include Sushi::Core::Hashes

--- a/src/core/keys/address.cr
+++ b/src/core/keys/address.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Keys
   include Hashes
   include Sushi::Core::Models

--- a/src/core/keys/blowfish.cr
+++ b/src/core/keys/blowfish.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "openssl/cipher"
 require "crypto/bcrypt/password"
 

--- a/src/core/keys/key_utils.cr
+++ b/src/core/keys/key_utils.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Keys
   include Sushi::Core::Hashes
   include Sushi::Core::Models

--- a/src/core/keys/private_key.cr
+++ b/src/core/keys/private_key.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Keys
   include Sushi::Core::Models
 

--- a/src/core/keys/public_key.cr
+++ b/src/core/keys/public_key.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Keys
   include Sushi::Core::Models
 

--- a/src/core/keys/wif.cr
+++ b/src/core/keys/wif.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Keys
   include Hashes
   include Sushi::Core::Models

--- a/src/core/miner.cr
+++ b/src/core/miner.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./miner/miner"

--- a/src/core/miner/miner.cr
+++ b/src/core/miner/miner.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   class Miner
     @wallet : Wallet

--- a/src/core/models.cr
+++ b/src/core/models.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./models/*"

--- a/src/core/models/chain.cr
+++ b/src/core/models/chain.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias Chain = Array(Block)
 end

--- a/src/core/models/domain.cr
+++ b/src/core/models/domain.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   module DomainStatus
     Acquired =  0

--- a/src/core/models/header.cr
+++ b/src/core/models/header.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias Header = NamedTuple(
     index: Int64,

--- a/src/core/models/miner.cr
+++ b/src/core/models/miner.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias Miner = NamedTuple(
     address: String,

--- a/src/core/models/network.cr
+++ b/src/core/models/network.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias Network = NamedTuple(
     prefix: String,

--- a/src/core/models/node.cr
+++ b/src/core/models/node.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias NodeContext = NamedTuple(
     id: String,

--- a/src/core/models/recipient.cr
+++ b/src/core/models/recipient.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias Recipient = NamedTuple(
     address: String,

--- a/src/core/models/sender.cr
+++ b/src/core/models/sender.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Models
   alias Sender = NamedTuple(
     address: String,

--- a/src/core/modules.cr
+++ b/src/core/modules.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./modules/*"

--- a/src/core/modules/hashes.cr
+++ b/src/core/modules/hashes.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Hashes
   def sha256(base : Bytes | String) : String
     hash = OpenSSL::Digest.new("SHA256")

--- a/src/core/modules/logger.cr
+++ b/src/core/modules/logger.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Logger
   def debug(msg : String)
     return if ENV.has_key?("UNIT") || ENV.has_key?("E2E")

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./node/*"
 
 module ::Sushi::Core

--- a/src/core/node/controllers.cr
+++ b/src/core/node/controllers.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Controllers
   abstract class Controller
     def initialize(@blockchain : Blockchain)

--- a/src/core/node/controllers/handshake_controller.cr
+++ b/src/core/node/controllers/handshake_controller.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Controllers
   class HandshakeController < Controller
     def exec_internal_get(context, params) : HTTP::Server::Context

--- a/src/core/node/controllers/health_controller.cr
+++ b/src/core/node/controllers/health_controller.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Controllers
   class HealthController < Controller
     def exec_internal_get(context, params) : HTTP::Server::Context

--- a/src/core/node/controllers/rpc_controller.cr
+++ b/src/core/node/controllers/rpc_controller.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Controllers
   class RPCController < Controller
     def exec_internal_post(json, context, params) : HTTP::Server::Context

--- a/src/core/node/handlers.cr
+++ b/src/core/node/handlers.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./handlers/*"

--- a/src/core/node/handlers/web_socket_handler.cr
+++ b/src/core/node/handlers/web_socket_handler.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core
   class WebSocketHandler < HTTP::WebSocketHandler
     def initialize(@path : String, &@proc : HTTP::WebSocket, HTTP::Server::Context -> Void)

--- a/src/core/protocol.cr
+++ b/src/core/protocol.cr
@@ -1,1 +1,13 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "./protocol/*"

--- a/src/core/protocol/protocol.cr
+++ b/src/core/protocol/protocol.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 module ::Sushi::Core::Protocol
   def send(socket, t, content)
     socket.send({type: t, content: content.to_json}.to_json)

--- a/tools/add_license.cr
+++ b/tools/add_license.cr
@@ -10,6 +10,10 @@
 #
 # Removal or modification of this copyright notice is prohibited.
 
+if !Dir.entries.include?("add_license.cr")
+  puts "Error: you must execute this file from the tools directory - please cd to the tools dir and run crystal run add_license.cr"
+end
+
 LICENSE = <<-LIC
 # Copyright © 2017-2018 The SushiChain Core developers
 #

--- a/tools/add_license.cr
+++ b/tools/add_license.cr
@@ -1,0 +1,37 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+LICENSE = <<-LIC
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+LIC
+
+Dir["../**/*.cr"].reject{|f| f.starts_with?("../lib")}.each do |file_path|
+   lines = File.read_lines(file_path)
+   if lines.first.starts_with?("# Copyright")
+     puts "Good : #{file_path}"
+   else
+     puts "Amending : #{file_path}"
+     content = [LICENSE] + lines
+     File.open(file_path, "w"){|file| file.puts content.join("\n")}
+   end
+end

--- a/tools/total_amount.cr
+++ b/tools/total_amount.cr
@@ -1,3 +1,15 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
 require "../src/core"
 
 total_amount = 0_i64


### PR DESCRIPTION
This adds the license blurb to the top of each crystal file

Additionally there is a spec which fails if it finds one of our crystal files with no license at the top
The license is automatically added by running tools/add_license.cr

e.g.
```
cd tools
crystal run add_license.cr
```

If the license is already there it ignores and carries on