### PR TITLE
only print the message instead of the stack trace when encountering a raised exception

### DIFF
--- a/src/cli/sushi/blockchain.cr
+++ b/src/cli/sushi/blockchain.cr
@@ -50,6 +50,8 @@ module ::Sushi::Interface::Sushi
       end
 
       specify_sub_action!(action_name)
+    rescue e : Exception
+      puts_error e.message    
     end
 
     def size

--- a/src/cli/sushi/config.cr
+++ b/src/cli/sushi/config.cr
@@ -65,6 +65,8 @@ module ::Sushi::Interface::Sushi
       end
 
       specify_sub_action!(action_name)
+    rescue e : Exception
+      puts_error e.message  
     end
 
     def save

--- a/src/cli/sushi/scars.cr
+++ b/src/cli/sushi/scars.cr
@@ -65,6 +65,8 @@ module ::Sushi::Interface::Sushi
       end
 
       specify_sub_action!
+    rescue e : Exception
+      puts_error e.message  
     end
 
     def buy

--- a/src/cli/sushi/token.cr
+++ b/src/cli/sushi/token.cr
@@ -47,6 +47,8 @@ module ::Sushi::Interface::Sushi
       end
 
       specify_sub_action!
+    rescue e : Exception
+      puts_error e.message
     end
 
     def create

--- a/src/cli/sushi/transaction.cr
+++ b/src/cli/sushi/transaction.cr
@@ -70,6 +70,8 @@ module ::Sushi::Interface::Sushi
       end
 
       specify_sub_action!(action_name)
+    rescue e : Exception
+      puts_error e.message   
     end
 
     def create

--- a/src/cli/sushi/wallet.cr
+++ b/src/cli/sushi/wallet.cr
@@ -67,6 +67,8 @@ module ::Sushi::Interface::Sushi
       end
 
       specify_sub_action!(action_name)
+    rescue e : Exception
+      puts_error e.message  
     end
 
     def create


### PR DESCRIPTION
I added a rescue at the run_impl(action_name) to catch any raised Exceptions and just print the error message and not the stack trace - when executing sushi