### PR TITLE
kings - allow -w,-n,--password to be unset in config

### DIFF
--- a/src/cli/modules/config_manager.cr
+++ b/src/cli/modules/config_manager.cr
@@ -33,6 +33,11 @@ module ::Sushi::Interface
       @config_map[name] = value
     end
 
+    def unsettable(name : String, value : Configurable)
+      return if value.is_a?(Nil)
+      value.to_s.ends_with?("!") ? @config_map.delete(name) : (@config_map[name] = value)
+    end
+
     def get_config : YAML::Any?
       return nil unless File.exists?(config_path)
 

--- a/src/cli/sushi/config.cr
+++ b/src/cli/sushi/config.cr
@@ -69,8 +69,8 @@ module ::Sushi::Interface::Sushi
     end
 
     def save
-      cm.set("connect_node", __connect_node)
-      cm.set("wallet_path", absolute_path(__wallet_path))
+      cm.unsettable("connect_node", __connect_node)
+      cm.unsettable("wallet_path", absolute_path(__wallet_path))
       cm.set("is_testnet", __is_testnet)
       cm.set("is_private", __is_private)
       cm.set("bind_host", __bind_host)
@@ -79,7 +79,7 @@ module ::Sushi::Interface::Sushi
       cm.set("database_path", __database_path)
       cm.set("threads", __threads)
       cm.set("encrypted", __encrypted)
-      cm.set("wallet_password", __wallet_password)
+      cm.unsettable("wallet_password", __wallet_password)
       cm.save
 
       puts_success "saved the configuration at #{cm.config_path}"


### PR DESCRIPTION
This allows you to unset 3 pieces of config

* -w (wallet_path)
* -n (connecting_node)
* --password (wallet_password)

I found when I set up my configuration with the -n, -w, --testnet and --password this is great for most use cases. But when I want to do some other things like check the balance on a different address for example - I have to clean the whole config and then re-type it in again - or just not use the config. This is because -w is already set - so you don't get the chance to supply -a.

This is my proposed fix:

```
sushi config save -w w1.json <= saves the wallet to config
sushi config save -w ! <= removes the wallet from config
```
so when I want to remove only a specific value for one of those 3 - I can pass `!` as the argument value.