### PR TITLE
pubsub endpoint

### DIFF
--- a/src/cli/sushi.cr
+++ b/src/cli/sushi.cr
@@ -41,6 +41,10 @@ module ::Sushi::Interface::Sushi
           name: "config",
           desc: "save default configuration used by sushi, sushid and sushim (cg for short)",
         },
+        {
+          name: "pubsub",
+          desc: "receive blocks in realtime",
+        },
       ]
     end
 
@@ -78,6 +82,11 @@ module ::Sushi::Interface::Sushi
       when "config", "cg"
         return Config.new(
           {name: "config", desc: "save default configuration used by sushi, sushid and sushim"},
+          next_parents,
+        ).run
+      when "pubsub", "ps"
+        return Pubsub.new(
+          {name: "pubsub", desc: "receive blocks in realtime"},
           next_parents,
         ).run
       end

--- a/src/cli/sushi/pubsub.cr
+++ b/src/cli/sushi/pubsub.cr
@@ -18,9 +18,9 @@ module ::Sushi::Interface::Sushi
 
     def option_parser
       create_option_parser([
-                             Options::CONNECT_NODE,
-                             Options::JSON,
-                           ])
+        Options::CONNECT_NODE,
+        Options::JSON,
+      ])
     end
 
     def puts_line

--- a/src/cli/sushi/pubsub.cr
+++ b/src/cli/sushi/pubsub.cr
@@ -1,0 +1,63 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+module ::Sushi::Interface::Sushi
+  class Pubsub < CLI
+    def sub_actions
+      [] of SushiAction
+    end
+
+    def option_parser
+      create_option_parser([
+                             Options::CONNECT_NODE,
+                             Options::JSON,
+                           ])
+    end
+
+    def puts_line
+      puts "+#{"-" * 22}+#{"-" * 66}|"
+    end
+
+    def puts_line(name, value)
+      puts "| %20s | %64s |" % [name, value]
+    end
+
+    def run_impl(action_name)
+      puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
+
+      node_uri = URI.parse(node)
+      use_ssl = (node_uri.scheme == "https")
+
+      socket = HTTP::WebSocket.new(node_uri.host.not_nil!, "/pubsub", node_uri.port.not_nil!, use_ssl)
+      socket.on_message do |message|
+        if __json
+          puts message
+        else
+          block = Core::Block.from_json(message)
+
+          puts_line
+          puts_line("index", block.index)
+          puts_line("nonce", block.nonce)
+          puts_line("prev_hash", block.prev_hash)
+          puts_line("merkle_tree_root", block.merkle_tree_root)
+          puts_line
+        end
+      end
+
+      puts_success "Start listening new blocks..." unless __json
+
+      socket.run
+    end
+
+    include GlobalOptionParser
+  end
+end

--- a/src/core/node/controllers/pubsub_controller.cr
+++ b/src/core/node/controllers/pubsub_controller.cr
@@ -1,0 +1,47 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+module ::Sushi::Core::Controllers
+  class PubsubController
+    @sockets : Array(HTTP::WebSocket) = [] of HTTP::WebSocket
+
+    def initialize
+    end
+
+    def pubsub(socket : HTTP::WebSocket)
+      socket.on_close do |_|
+        @sockets.delete(socket)
+        debug "a pubsub subscriber disconnected (#{@sockets.size})"
+      end
+
+      @sockets << socket
+      debug "new pubsub subscriber coming (#{@sockets.size})"
+    end
+
+    def broadcast(block)
+      debug "broadcast to the subscribers (#{@sockets.size})"
+
+      @sockets.each do |socket|
+        socket.send(block.to_json)
+      rescue e : Exception
+        @sockets.delete(socket)
+        debug "a pubsub subscriber disconnected (#{@sockets.size})"
+      end
+    end
+
+    def get_handler
+      WebSocketHandler.new("/pubsub") { |socket, context| pubsub(socket) }
+    end
+
+    include Logger
+  end
+end

--- a/src/core/node/controllers/rpc_controller.cr
+++ b/src/core/node/controllers/rpc_controller.cr
@@ -32,5 +32,26 @@ module ::Sushi::Core::Controllers
       context.response.print api_error("unpermitted call: #{call}")
       context
     end
+
+    def get_handler
+      options "/rpc" do |context|
+        context.response.headers["Allow"] = "HEAD,GET,PUT,POST,DELETE,OPTIONS"
+        context.response.headers["Access-Control-Allow-Origin"] = "*"
+        context.response.headers["Access-Control-Allow-Headers"] =
+          "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept"
+        context.response.status_code = 200
+        context.response.print ""
+        context
+      end
+
+      post "/rpc" do |context, params|
+        context.response.headers["Access-Control-Allow-Origin"] = "*"
+        exec(context, params)
+      end
+
+      route_handler
+    end
+
+    include Router
   end
 end

--- a/src/core/node/handlers/web_socket_handler.cr
+++ b/src/core/node/handlers/web_socket_handler.cr
@@ -16,7 +16,11 @@ module ::Sushi::Core
     end
 
     def call(context : HTTP::Server::Context)
-      super(context)
+      if context.request.path == @path
+        super(context)
+      else
+        call_next(context)
+      end
     end
   end
 end


### PR DESCRIPTION
Added websocket endpoint `pubsub`.
When subscribers connect to there, they will receive new broadcasted blocks.

I also created sample client `sushi pubsub` which just connect to the endpoint and print out the coming blocks.