### PR TITLE
config override

### DIFF
--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -210,7 +210,7 @@ module ::Sushi::Interface
           @token = token
         } if is_active?(actives, Options::TOKEN)
 
-        parser.on("--name=CONFIG_NAME", "specify a config name") { |name|
+        parser.on("-c", "--config=CONFIG_NAME", "specify a config name") { |name|
           @config_name = name
         } if is_active?(actives, Options::CONFIG_NAME)
       end
@@ -222,28 +222,28 @@ module ::Sushi::Interface
 
     def __connect_node : String?
       return @connect_node if @connect_node
-      cm.get_s("connect_node")
+      cm.get_s("connect_node", @config_name)
     end
 
     def __wallet_path : String?
       return @wallet_path if @wallet_path
-      cm.get_s("wallet_path")
+      cm.get_s("wallet_path", @config_name)
     end
 
     def __wallet_password : String?
       return @wallet_password if @wallet_password
-      cm.get_s("wallet_password")
+      cm.get_s("wallet_password", @config_name)
     end
 
     def __is_testnet : Bool
       return @is_testnet if @is_testnet_changed
-      return cm.get_bool("is_testnet").not_nil! if cm.get_bool("is_testnet")
+      return cm.get_bool("is_testnet", @config_name).not_nil! if cm.get_bool("is_testnet", @config_name)
       @is_testnet
     end
 
     def __is_private : Bool
       return @is_private if @is_private_changed
-      return cm.get_bool("is_private").not_nil! if cm.get_bool("is_private")
+      return cm.get_bool("is_private", @config_name).not_nil! if cm.get_bool("is_private", @config_name)
       @is_private
     end
 
@@ -257,29 +257,29 @@ module ::Sushi::Interface
 
     def __bind_host : String
       return @bind_host if @bind_host != "0.0.0.0"
-      return cm.get_s("bind_host").not_nil! if cm.get_s("bind_host")
+      return cm.get_s("bind_host", @config_name).not_nil! if cm.get_s("bind_host", @config_name)
       @bind_host
     end
 
     def __bind_port : Int32
       return @bind_port if @bind_port != 3000
-      return cm.get_i32("bind_port").not_nil! if cm.get_i32("bind_port")
+      return cm.get_i32("bind_port", @config_name).not_nil! if cm.get_i32("bind_port", @config_name)
       @bind_port
     end
 
     def __public_url : String?
       return @public_url if @public_url
-      cm.get_s("public_url")
+      cm.get_s("public_url", @config_name)
     end
 
     def __database_path : String?
       return @database_path if @database_path
-      cm.get_s("database_path")
+      cm.get_s("database_path", @config_name)
     end
 
     def __address : String?
       return @address if @address
-      cm.get_s("address")
+      cm.get_s("address", @config_name)
     end
 
     def __amount : String?
@@ -312,13 +312,13 @@ module ::Sushi::Interface
 
     def __threads : Int32
       return @threads if @threads != 1
-      return cm.get_i32("threads").not_nil! if cm.get_i32("threads")
+      return cm.get_i32("threads", @config_name).not_nil! if cm.get_i32("threads", @config_name)
       @threads
     end
 
     def __encrypted : Bool
       return @encrypted if @encrypted
-      return cm.get_bool("encrypted").not_nil! if cm.get_bool("encrypted")
+      return cm.get_bool("encrypted", @config_name).not_nil! if cm.get_bool("encrypted", @config_name)
       @encrypted
     end
 
@@ -328,7 +328,7 @@ module ::Sushi::Interface
 
     def __domain : String?
       return @domain if @domain
-      cm.get_s("domain")
+      cm.get_s("domain", @config_name)
     end
 
     def __token : String?

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -229,7 +229,7 @@ module ::Sushi::Interface
     end
 
     def __wallet_password : String?
-        with_string_config("wallet_password", @wallet_password)
+      with_string_config("wallet_password", @wallet_password)
     end
 
     def __is_testnet : Bool

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -221,18 +221,15 @@ module ::Sushi::Interface
     end
 
     def __connect_node : String?
-      return @connect_node if @connect_node
-      cm.get_s("connect_node", @config_name)
+      with_string_config("connect_node", @connect_node)
     end
 
     def __wallet_path : String?
-      return @wallet_path if @wallet_path
-      cm.get_s("wallet_path", @config_name)
+      with_string_config("wallet_path", @wallet_path)
     end
 
     def __wallet_password : String?
-      return @wallet_password if @wallet_password
-      cm.get_s("wallet_password", @config_name)
+        with_string_config("wallet_password", @wallet_password)
     end
 
     def __is_testnet : Bool
@@ -268,18 +265,15 @@ module ::Sushi::Interface
     end
 
     def __public_url : String?
-      return @public_url if @public_url
-      cm.get_s("public_url", @config_name)
+      with_string_config("public_url", @public_url)
     end
 
     def __database_path : String?
-      return @database_path if @database_path
-      cm.get_s("database_path", @config_name)
+      with_string_config("database_path", @database_path)
     end
 
     def __address : String?
-      return @address if @address
-      cm.get_s("address", @config_name)
+      with_string_config("address", @address)
     end
 
     def __amount : String?
@@ -327,8 +321,7 @@ module ::Sushi::Interface
     end
 
     def __domain : String?
-      return @domain if @domain
-      cm.get_s("domain", @config_name)
+      with_string_config("domain", @domain)
     end
 
     def __token : String?
@@ -349,6 +342,11 @@ module ::Sushi::Interface
     rescue e : InvalidBigDecimalException
       puts_error "please supply valid decimal number: #{value}"
       exit -1
+    end
+
+    private def with_string_config(name, var)
+      return var if var
+      cm.get_s(name, @config_name)
     end
 
     include Logger

--- a/src/cli/sushi/blockchain.cr
+++ b/src/cli/sushi/blockchain.cr
@@ -36,6 +36,7 @@ module ::Sushi::Interface::Sushi
         Options::BLOCK_INDEX,
         Options::TRANSACTION_ID,
         Options::HEADER,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushi/config.cr
+++ b/src/cli/sushi/config.cr
@@ -96,6 +96,7 @@ module ::Sushi::Interface::Sushi
 
     def save
       cm.set_enabled_state(ConfigStatus::Disabled)
+      cm.set_override_state(false)
       cm.set("connect_node", __connect_node)
       cm.set("wallet_path", absolute_path(__wallet_path))
       cm.set("is_testnet", __is_testnet)
@@ -111,7 +112,7 @@ module ::Sushi::Interface::Sushi
       cm.set("domain", __domain)
       cm.save(__name)
       cm.set_enabled_state(ConfigStatus::Enabled)
-
+      cm.set_override_state(true)
       puts_success "saved the configuration at #{cm.config_path}"
 
       cm.release_config

--- a/src/cli/sushi/pubsub.cr
+++ b/src/cli/sushi/pubsub.cr
@@ -20,6 +20,7 @@ module ::Sushi::Interface::Sushi
       create_option_parser([
         Options::CONNECT_NODE,
         Options::JSON,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushi/scars.cr
+++ b/src/cli/sushi/scars.cr
@@ -47,6 +47,7 @@ module ::Sushi::Interface::Sushi
         Options::FEE,
         Options::PRICE,
         Options::DOMAIN,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushi/token.cr
+++ b/src/cli/sushi/token.cr
@@ -35,6 +35,7 @@ module ::Sushi::Interface::Sushi
         Options::FEE,
         Options::PRICE,
         Options::TOKEN,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushi/transaction.cr
+++ b/src/cli/sushi/transaction.cr
@@ -52,6 +52,7 @@ module ::Sushi::Interface::Sushi
         Options::FEE,
         Options::DOMAIN,
         Options::TOKEN,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushi/wallet.cr
+++ b/src/cli/sushi/wallet.cr
@@ -49,6 +49,7 @@ module ::Sushi::Interface::Sushi
         Options::ADDRESS,
         Options::DOMAIN,
         Options::TOKEN,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushid.cr
+++ b/src/cli/sushid.cr
@@ -29,6 +29,7 @@ module ::Sushi::Interface::SushiD
         Options::BIND_PORT,
         Options::PUBLIC_URL,
         Options::DATABASE_PATH,
+        Options::CONFIG_NAME,
       ])
     end
 

--- a/src/cli/sushim.cr
+++ b/src/cli/sushim.cr
@@ -25,6 +25,7 @@ module ::Sushi::Interface::SushiM
         Options::WALLET_PASSWORD,
         Options::IS_TESTNET,
         Options::THREADS,
+        Options::CONFIG_NAME,  
       ])
     end
 


### PR DESCRIPTION
## Description
This provides a config override using either `-c` or `--config=` as follows:

```
sushi wt amount -c wallet1
sushi wt amount -c wallet2
sushid --config=testnet_sushid
sushim -config=miner1 
```

The default configuration still works if no override is provided e.g. 

```
sushi config use --config=wallet1
sushi wt amount 
```

## Related Issues
#175 

## Checklist
- [x] Every CI jobs finished successfully

