### PR TITLE
[WIP] 2fa

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -1,5 +1,13 @@
 version: 1.0
 shards:
+  crystal-base32:
+    github: SushiChain/crystal-base32
+    commit: b013e73c44fcbe7a4b20a46b5b1d959efcc70bad
+
+  crystal-two-factor-auth:
+    github: SushiChain/crystal-two-factor-auth
+    commit: 3e3b54dca6d10ef557344ca84196ca832bd6fa5d
+
   db:
     github: crystal-lang/crystal-db
     version: 0.5.0

--- a/shard.yml
+++ b/shard.yml
@@ -26,6 +26,9 @@ dependencies:
     github: crystal-lang/crystal-sqlite3
   scrypt:
     github: ysbaddaden/scrypt-crystal
+  crystal-two-factor-auth:
+    github: SushiChain/crystal-two-factor-auth    
+
 
 crystal: 0.24.1
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -154,11 +154,12 @@ module ::Sushi::Interface
                         senders : SendersDecimal,
                         recipients : RecipientsDecimal,
                         message : String,
-                        token : String)
+                        token : String,
+                        auth_code : String)
       raise "mimatch for wallet size and sender's size" if wallets.size != senders.size
 
       unsigned_transaction =
-        create_unsigned_transaction(node, action, senders, recipients, message, token)
+        create_unsigned_transaction(node, action, senders, recipients, message, token, auth_code)
 
       signed_transaction = sign(wallets, unsigned_transaction)
 
@@ -182,7 +183,8 @@ module ::Sushi::Interface
                                     senders : SendersDecimal,
                                     recipients : RecipientsDecimal,
                                     message : String,
-                                    token : String) : Core::Transaction
+                                    token : String,
+                                    auth_code : String) : Core::Transaction
       payload = {
         call:       "create_unsigned_transaction",
         action:     action,
@@ -190,6 +192,7 @@ module ::Sushi::Interface
         recipients: recipients,
         message:    message,
         token:      token,
+        auth_code:  auth_code,
       }.to_json
 
       body = rpc(node, payload)
@@ -203,6 +206,13 @@ module ::Sushi::Interface
 
     def resolve_internal(node, domain, confirmation : Int32) : JSON::Any
       payload = {call: "scars_resolve", domain_name: domain, confirmation: confirmation}.to_json
+
+      body = rpc(node, payload)
+      JSON.parse(body)
+    end
+
+    def resolve_2fa_secret(node, address, confirmation : Int32) : JSON::Any
+      payload = {call: "2fa_resolve", address: address, confirmation: confirmation}.to_json
 
       body = rpc(node, payload)
       JSON.parse(body)

--- a/src/cli/helps/helps.cr
+++ b/src/cli/helps/helps.cr
@@ -30,5 +30,6 @@ module ::Sushi::Interface
     HELP_TOKEN_AMOUNT                     = "please specify the token amount: -m [amount]"
     HELP_CONFIG_NAME                      = "please specify the config name: --name=[name]"
     HELP_NODE_ID                          = "please specify a node id: --node_id=[node_id]"
+    HELP_AUTH_CODE                        = "please specify an auth code: --auth_code=[auth_code]"
   end
 end

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -46,6 +46,7 @@ module ::Sushi::Interface
     @domain : String?
 
     @token : String?
+    @auth_code : String?
 
     @config_name : String?
 
@@ -89,6 +90,8 @@ module ::Sushi::Interface
       CONFIG_NAME
       # for node
       NODE_ID
+      # for 2fa
+      AUTH_CODE
     end
 
     def create_option_parser(actives : Array(Options)) : OptionParser
@@ -221,6 +224,10 @@ module ::Sushi::Interface
         parser.on("--node_id=NODE_ID", "specify a node id") { |node_id|
           @node_id = node_id
         } if is_active?(actives, Options::NODE_ID)
+
+        parser.on("--auth_code=AUTH_CODE", "supply 2fa auth code for transaction") { |auth_code|
+          @auth_code = auth_code
+        } if is_active?(actives, Options::AUTH_CODE)
       end
     end
 
@@ -342,6 +349,10 @@ module ::Sushi::Interface
 
     def __node_id : String?
       @node_id
+    end
+
+    def __auth_code : String?
+      @auth_code
     end
 
     def cm

--- a/src/cli/sushi.cr
+++ b/src/cli/sushi.cr
@@ -49,6 +49,10 @@ module ::Sushi::Interface::Sushi
           name: "pubsub",
           desc: "receive blocks in realtime",
         },
+        {
+          name: "2fa",
+          desc: "enable or disable 2fa for transactions",
+        },
       ]
     end
 
@@ -96,6 +100,11 @@ module ::Sushi::Interface::Sushi
       when "pubsub", "ps"
         return Pubsub.new(
           {name: "pubsub", desc: "receive blocks in realtime"},
+          next_parents,
+        ).run
+      when "2fa", "2f"
+        return Auth.new(
+          {name: "2fa", desc: "enable or disable 2fa for transactions"},
           next_parents,
         ).run
       end

--- a/src/cli/sushi/2fa.cr
+++ b/src/cli/sushi/2fa.cr
@@ -117,14 +117,23 @@ module ::Sushi::Interface::Sushi
     end
 
     def verify
-      puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
+        puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
         puts_help(HELP_WALLET_PATH) unless wallet_path = __wallet_path
         puts_help(HELP_AUTH_CODE) unless auth_code = __auth_code
 
         wallet = get_wallet(wallet_path, __wallet_password)
-        p secret_code = resolve_2fa_secret(node, wallet.address, 1)
+        secret_code_response = resolve_2fa_secret(node, wallet.address, 1)
+        secret_code = secret_code_response["secret_code"]["secret_code"].to_s
+        raise "2fa is not enabled on this address" if secret_code.empty?
+        puts "verifying 2fa ..."
+        result = TOTP.validate_number_string(secret_code, auth_code)
+        if result
+          puts_success("The 2fa code you supplied was successfully validated!")
+        else
+          puts_error("The 2fa code you supplied was incorrect!")
+        end
 
-        puts "verifying....2fa"
+
     end
 
     include GlobalOptionParser

--- a/src/cli/sushi/2fa.cr
+++ b/src/cli/sushi/2fa.cr
@@ -1,0 +1,133 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+module ::Sushi::Interface::Sushi
+  class Auth < CLI
+    def sub_actions
+      [
+        {
+          name: "enable",
+          desc: "enable 2fa",
+        },
+        {
+          name: "disable",
+          desc: "disable 2fa",
+        },
+        {
+          name: "verify",
+          desc: "verify 2fa",
+        },
+      ]
+    end
+
+    def option_parser
+      create_option_parser([
+        Options::CONNECT_NODE,
+        Options::WALLET_PATH,
+        Options::WALLET_PASSWORD,
+        Options::JSON,
+        Options::CONFIRMATION,
+        Options::FEE,
+        Options::AUTH_CODE,
+        Options::CONFIG_NAME,
+      ])
+    end
+
+    def run_impl(action_name)
+      case action_name
+      when "enable"
+        return enable
+      when "disable"
+        return disable
+      when "verify"
+        return verify
+      end
+
+      specify_sub_action!
+    rescue e : Exception
+      puts_error e.message
+      exit -1
+    end
+
+    def enable
+      puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
+      puts_help(HELP_WALLET_PATH) unless wallet_path = __wallet_path
+      puts_help(HELP_FEE) unless fee = __fee
+
+      wallet = get_wallet(wallet_path, __wallet_password)
+      resolved_secret_code = resolve_2fa_secret(node, wallet.address, 1)
+      raise "2fa is already enabled on this address" if resolved_secret_code["secret_code"]["status"] == Core::DApps::BuildIn::Auth::Status::Enabled
+
+      wallet = get_wallet(wallet_path, __wallet_password)
+
+      senders = SendersDecimal.new
+      senders.push({
+        address:    wallet.address,
+        public_key: wallet.public_key,
+        amount:     "0",
+        fee:        fee,
+        sign_r:     "0",
+        sign_s:     "0",
+      })
+
+      recipients = RecipientsDecimal.new
+      recipients.push({
+        address: wallet.address,
+        amount:  "0",
+      })
+
+      generated_secret_code = TOTP.generate_base32_secret
+      add_transaction(node, "2fa_enable", [wallet], senders, recipients, "", TOKEN_DEFAULT, generated_secret_code)
+    end
+
+    def disable
+      puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
+      puts_help(HELP_WALLET_PATH) unless wallet_path = __wallet_path
+      puts_help(HELP_FEE) unless fee = __fee
+      puts_help(HELP_AUTH_CODE) unless auth_code = __auth_code
+
+      wallet = get_wallet(wallet_path, __wallet_password)
+
+      senders = SendersDecimal.new
+      senders.push({
+        address:    wallet.address,
+        public_key: wallet.public_key,
+        amount:     "0",
+        fee:        fee,
+        sign_r:     "0",
+        sign_s:     "0",
+      })
+
+      recipients = RecipientsDecimal.new
+      recipients.push({
+        address: wallet.address,
+        amount:  "0",
+      })
+
+      add_transaction(node, "2fa_disable", [wallet], senders, recipients, "", TOKEN_DEFAULT, auth_code)
+    end
+
+    def verify
+      puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
+        puts_help(HELP_WALLET_PATH) unless wallet_path = __wallet_path
+        puts_help(HELP_AUTH_CODE) unless auth_code = __auth_code
+
+        wallet = get_wallet(wallet_path, __wallet_password)
+        p secret_code = resolve_2fa_secret(node, wallet.address, 1)
+
+        puts "verifying....2fa"
+    end
+
+    include GlobalOptionParser
+  end
+
+end

--- a/src/cli/sushi/scars.cr
+++ b/src/cli/sushi/scars.cr
@@ -106,7 +106,7 @@ module ::Sushi::Interface::Sushi
         })
       end
 
-      add_transaction(node, "scars_buy", [wallet], senders, recipients, domain, TOKEN_DEFAULT)
+      add_transaction(node, "scars_buy", [wallet], senders, recipients, domain, TOKEN_DEFAULT, "")
     end
 
     def sell
@@ -142,7 +142,7 @@ module ::Sushi::Interface::Sushi
         amount:  price,
       })
 
-      add_transaction(node, "scars_sell", [wallet], senders, recipients, domain, TOKEN_DEFAULT)
+      add_transaction(node, "scars_sell", [wallet], senders, recipients, domain, TOKEN_DEFAULT, "")
     end
 
     def cancel
@@ -177,7 +177,7 @@ module ::Sushi::Interface::Sushi
         amount:  "0",
       })
 
-      add_transaction(node, "scars_cancel", [wallet], senders, recipients, domain, TOKEN_DEFAULT)
+      add_transaction(node, "scars_cancel", [wallet], senders, recipients, domain, TOKEN_DEFAULT, "")
     end
 
     def sales

--- a/src/cli/sushi/token.cr
+++ b/src/cli/sushi/token.cr
@@ -79,7 +79,7 @@ module ::Sushi::Interface::Sushi
         amount:  amount,
       })
 
-      add_transaction(node, "create_token", [wallet], senders, recipients, "", token)
+      add_transaction(node, "create_token", [wallet], senders, recipients, "", token, "")
     end
 
     def list

--- a/src/cli/sushi/transaction.cr
+++ b/src/cli/sushi/transaction.cr
@@ -118,7 +118,7 @@ module ::Sushi::Interface::Sushi
         }
       )
 
-      add_transaction(node, action, wallets, senders, recipients, __message, __token || TOKEN_DEFAULT)
+      add_transaction(node, action, wallets, senders, recipients, __message, __token || TOKEN_DEFAULT, __auth_code || "")
     end
 
     def transactions

--- a/src/core.cr
+++ b/src/core.cr
@@ -26,6 +26,7 @@ require "tokoroten"
 require "http/server"
 require "openssl/pkcs5"
 require "openssl/digest"
+require "crystal-two-factor-auth"
 
 require "./common"
 require "./core/modules"

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -278,6 +278,7 @@ module ::Sushi::Core
         TOKEN_DEFAULT, # token
         "0",           # prev_hash
         timestamp,     # timestamp
+        "0",           # auth_code
         1,             # scaled
       )
     end

--- a/src/core/blockchain/transaction.cr
+++ b/src/core/blockchain/transaction.cr
@@ -26,6 +26,7 @@ module ::Sushi::Core
       token: String,
       prev_hash: String,
       timestamp: Int64,
+      auth_code: String,
       scaled: Int32,
     )
 
@@ -40,6 +41,7 @@ module ::Sushi::Core
       @token : String,
       @prev_hash : String,
       @timestamp : Int64,
+      @auth_code : String,
       @scaled : Int32
     )
     end
@@ -145,6 +147,7 @@ module ::Sushi::Core
         self.token,
         "0",
         self.timestamp,
+        self.auth_code,
         self.scaled,
       )
     end
@@ -176,6 +179,7 @@ module ::Sushi::Core
         self.token,
         "0",
         self.timestamp,
+        self.auth_code,
         self.scaled,
       )
     end

--- a/src/core/blockchain/transaction/decimal.cr
+++ b/src/core/blockchain/transaction/decimal.cr
@@ -21,6 +21,7 @@ module ::Sushi::Core
       token: String,
       prev_hash: String,
       timestamp: Int64,
+      auth_code: String,
       scaled: Int32,
     )
 
@@ -33,6 +34,7 @@ module ::Sushi::Core
       @token : String,
       @prev_hash : String,
       @timestamp : Int64,
+      @auth_code : String,
       @scaled : Int32
     )
       raise "invalid decimal transaction (expected scaled: 0 bug receive #{@scaled})" if @scaled != 0
@@ -48,6 +50,7 @@ module ::Sushi::Core
         @token,
         @prev_hash,
         @timestamp,
+        @auth_code,
         1,
       )
     end
@@ -62,6 +65,7 @@ module ::Sushi::Core
         transaction.token,
         transaction.prev_hash,
         transaction.timestamp,
+        transaction.auth_code,
         0,
       )
     end

--- a/src/core/dapps/build_in.cr
+++ b/src/core/dapps/build_in.cr
@@ -13,7 +13,7 @@
 require "./build_in/*"
 
 module ::Sushi::Core::DApps::BuildIn
-  BUILD_IN_DAPPS = %w(BlockchainInfo NodeInfo TransactionCreator UTXO Scars Token Indices Rejects Fees)
+  BUILD_IN_DAPPS = %w(BlockchainInfo NodeInfo TransactionCreator UTXO Scars Token Indices Rejects Fees Auth)
 
   {% for dapp in BUILD_IN_DAPPS %}
     @{{ dapp.id.underscore }} : {{ dapp.id }}?

--- a/src/core/dapps/build_in/2fa.cr
+++ b/src/core/dapps/build_in/2fa.cr
@@ -1,0 +1,257 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+module ::Sushi::Core::DApps::BuildIn
+
+  class Auth < DApp
+    enum Status
+      Enabled =  0
+      Disabled  =  1
+    end
+
+    alias SecretCode = NamedTuple(secret_code: String, address: String, status: Status)
+    alias AuthMap = Hash(String, SecretCode)
+
+    @auth_internal : Array(AuthMap) = Array(AuthMap).new
+
+    def setup
+    end
+
+    # def sales
+    #   domain_all = DomainMap.new
+    #
+    #   @domains_internal.reverse.each do |domain_map|
+    #     domain_map.each do |domain_name, domain|
+    #       domain_all[domain_name] ||= domain
+    #     end
+    #   end
+    #
+    #   domain_all
+    #     .select { |domain_name, domain| domain[:status] == Status::ForSale }
+    #     .map { |domain_name, domain| scale_decimal(domain) }
+    # end
+    #
+    # def resolve(domain_name : String, confirmation : Int32) : Domain?
+    #   return nil if @domains_internal.size < confirmation
+    #   resolve_for(domain_name, @domains_internal.reverse[(confirmation - 1)..-1])
+    # end
+    #
+    # def resolve_pending(domain_name : String, transactions : Array(Transaction)) : Domain?
+    #   domain_map = create_domain_map_for_transactions(transactions)
+    #
+    #   tmp_domains_internal = @domains_internal.dup
+    #   tmp_domains_internal.push(domain_map)
+    #
+    #   resolve_for(domain_name, tmp_domains_internal.reverse)
+    # end
+
+    def transaction_actions : Array(String)
+      ["2fa_enable", "2fa_disable"]
+    end
+
+    def transaction_related?(action : String) : Bool
+      action.starts_with?("2fa_")
+    end
+
+    def valid_transaction?(transaction : Transaction, prev_transactions : Array(Transaction)) : Bool
+      case transaction.action
+      when "2fa_enable"
+        return valid_enable?(transaction, prev_transactions)
+      when "2fa_disable"
+        return valid_disable?(transaction, prev_transactions)
+      end
+
+      false
+    end
+
+    def valid_enable?(transaction : Transaction, transactions : Array(Transaction)) : Bool
+      raise "senders have to be only one for 2fa action" if transaction.senders.size != 1
+      raise "you must pay by #{UTXO::DEFAULT} for 2fa" unless transaction.token == UTXO::DEFAULT
+
+      sender = transaction.senders[0]
+      recipients = transaction.recipients
+      secret_code = transaction.auth_code
+      address = sender[:address]
+      recipient_address = recipients[0][:address]
+
+      # valid_domain?(domain_name)
+      # check that 2fa is not already enabled
+      # check that supplied secret_code is valid
+
+      # raise "2fa address mismatch: #{recipient_address} vs #{domain[:address]}" if recipient_address != domain[:address]
+      raise "you cannot set multiple recipients" if recipients.size > 1
+
+      true
+    end
+
+    def valid_disable?(transaction : Transaction, transactions : Array(Transaction)) : Bool
+      raise "senders have to be only one for 2fa action" if transaction.senders.size != 1
+      raise "you have to set one recipient" if transaction.recipients.size != 1
+
+      sender = transaction.senders[0]
+      auth_code = transaction.auth_code
+      address = sender[:address]
+
+      # valid_domain?(domain_name)
+      # check that 2fa is already enabled
+      # check that the supplied auth_code is valid - check against transaction timestamp in millis and secret_code for the address
+
+      recipient = transaction.recipients[0]
+
+      # raise "domain #{domain_name} not found" unless domain = resolve_pending(domain_name, transactions)
+      # raise "domain #{domain_name} is already for sale now" if domain[:status] == Status::ForSale
+      # raise "domain address mismatch: expected #{address} but got #{domain[:address]}" unless address == domain[:address]
+      # raise "address mismatch for scars_sell: expected #{address} but got #{recipient[:address]}" if address != recipient[:address]
+      # raise "price mismatch for scars_sell: expected #{price} but got #{recipient[:amount]}" if price != recipient[:amount]
+      # raise "the selling price must be 0 or higher" if price < 0
+
+      true
+    end
+
+    def valid_auth_code?(auth_code)
+      true
+    end
+
+#     def valid_domain?(domain_name : String) : Bool
+#       Core::DApps::BuildIn::Scars.valid_domain?(domain_name)
+#     end
+#
+#     def self.valid_domain?(domain_name : String) : Bool
+#       unless domain_name =~ /^[a-zA-Z0-9]{1,20}\.(#{SUFFIX.join("|")})$/
+#         domain_rule = <<-RULE
+# Your domain '#{domain_name}' is not valid
+#
+# 1. domain name must contain only alphanumerics
+# 2. domain name must end with one of these suffixes: #{SUFFIX}
+# 3. domain name length must be between 1 and 20 characters (excluding suffix)
+# RULE
+#         raise domain_rule
+#       end
+#
+#       true
+#     end
+
+    def record(chain)
+      chain[@auth_internal.size..-1].each do |block|
+        auth_map = create_auth_map_for_transactions(block.transactions)
+        @auth_internal.push(auth_map)
+      end
+    end
+
+    def clear
+      @auth_internal.clear
+    end
+
+
+    def resolve(address : String, confirmation : Int32) : SecretCode?
+      return nil if @auth_internal.size < confirmation
+      resolve_for(address, @auth_internal.reverse[(confirmation - 1)..-1])
+    end
+
+    private def resolve_for(address : String, auths : Array(AuthMap)) : SecretCode?
+      auths.each do |auth_internal|
+        return auth_internal[address] if auth_internal[address]?
+      end
+
+      nil
+    end
+
+    private def create_auth_map_for_transactions(transactions : Array(Transaction)) : AuthMap
+      auth_map = AuthMap.new
+
+      transactions.each do |transaction|
+        next if transaction.action != "2fa_enable" &&
+                transaction.action != "2fa_disable"
+
+
+        secret_code = transaction.auth_code
+        address = transaction.senders[0][:address]
+
+        case transaction.action
+        when "2fa_enable"
+          auth_map[address] = {
+            secret_code: secret_code,
+            address:     address,
+            status:      Status::Enabled,
+          }
+        when "2fa_disable"
+          auth_map[address] = {
+            secret_code: secret_code,
+            address:     address,
+            status:      Status::Disabled,
+          }
+        end
+      end
+
+      auth_map
+    end
+
+    def self.fee(action : String) : Int64
+      case action
+      when "2fa_enable"
+        return scale_i64("0.0001")
+      when "2fa_disable"
+        return scale_i64("0.0001")
+      end
+
+      raise "got unknown action #{action} during getting a fee for 2fa"
+    end
+
+    def define_rpc?(call, json, context, params)
+      case call
+      when "2fa_resolve"
+        return resolve_2fa(json, context, params)
+      end
+
+      nil
+    end
+
+    def resolve_2fa(json, context, params)
+      address = json["address"].as_s
+      confirmation = json["confirmation"].as_i
+
+      context.response.print api_success(resolve_2fa_impl(address, confirmation))
+      context
+    end
+
+    def resolve_2fa_impl(address : String, confirmation : Int32)
+      secret_code = resolve(address, confirmation)
+
+      if secret_code
+        {resolved: true, confirmation: confirmation, secret_code: secret_code}
+      else
+        default_secret_code = {secret_code: "", address: address, status: Status::Disabled}
+        {resolved: false, confirmation: confirmation, secret_code: default_secret_code}
+      end
+    end
+
+    # def scars_for_sale(json, context, params)
+    #   context.response.print api_success(scars_for_sale_impl)
+    #   context
+    # end
+    #
+    # def scars_for_sale_impl
+    #   sales
+    # end
+
+    # def scale_decimal(domain : Domain)
+    #   {
+    #     domain_name: domain[:domain_name],
+    #     address:     domain[:address],
+    #     status:      domain[:status],
+    #     price:       scale_decimal(domain[:price]),
+    #   }
+    # end
+    #
+    # include Consensus
+  end
+end

--- a/src/core/dapps/build_in/transaction.cr
+++ b/src/core/dapps/build_in/transaction.cr
@@ -50,8 +50,9 @@ module ::Sushi::Core::DApps::BuildIn
       recipients = RecipientsDecimal.from_json(json["recipients"].to_json)
       message = json["message"].as_s
       token = json["token"].as_s
+      auth_code = json["auth_code"].as_s
 
-      transaction = create_unsigned_transaction_impl(action, senders, recipients, message, token)
+      transaction = create_unsigned_transaction_impl(action, senders, recipients, message, token, auth_code)
 
       context.response.print api_success(transaction)
       context
@@ -63,6 +64,7 @@ module ::Sushi::Core::DApps::BuildIn
       recipients : RecipientsDecimal,
       message : String,
       token : String,
+      auth_code : String,
       id : String = Transaction.create_id
     )
       transaction = TransactionDecimal.new(
@@ -74,6 +76,7 @@ module ::Sushi::Core::DApps::BuildIn
         token,
         "0",       # prev_hash
         timestamp, # timestamp
+        auth_code,
         0,         # scaled
       ).to_transaction
 

--- a/src/core/node/controllers/rest_controller.cr
+++ b/src/core/node/controllers/rest_controller.cr
@@ -185,6 +185,7 @@ module ::Sushi::Core::Controllers
           RecipientsDecimal.from_json(json["recipients"].to_json),
           json["message"].as_s,
           json["token"].as_s,
+          json["auth_code"].as_s,
         )
       end
     end


### PR DESCRIPTION
## Description
Start of 2fa at the transaction level

This is still Work in Progress

2fa provides 3 new sushi commands:

* sushi 2fa enable (enables 2fa on the supplied wallet)
* sushi 2fa disable (disabled 2fa on the supplied wallet)
* sushi 2fa verify (verifies if an auth code is valid)

This also adds an extra optional param to transaction creation: `--auth_code=` so when creating a transaction for an address that has 2fa enabled - it will be rejected unless the correct auth code is supplied. 

for a transaction the auth_code is applied against the transaction timestamp, for the command line sushi 2fa verify - it's done using the current time.

## Related Issues
<!-- Related Issues List -->
#97 


## Checklist
- [ ] Every CI jobs finished successfully

