### PR TITLE
[WIP] Give each miner a human readable hash

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,7 +2,11 @@ version: 1.0
 shards:
   db:
     github: crystal-lang/crystal-db
-    version: 0.5.0
+    version: 0.5.1
+
+  humanhash:
+    github: kingsleyh/humanhash
+    commit: aa533045dcc8986d6dba7f6408b8a10e578dad1e
 
   radix:
     github: luislavena/radix
@@ -10,7 +14,7 @@ shards:
 
   router:
     github: tbrand/router.cr
-    version: 0.2.3
+    version: 0.2.7
 
   scrypt:
     github: ysbaddaden/scrypt-crystal
@@ -18,9 +22,9 @@ shards:
 
   sqlite3:
     github: crystal-lang/crystal-sqlite3
-    version: 0.9.0
+    version: 0.10.0
 
   tokoroten:
     github: tbrand/tokoroten
-    version: 0.1.2
+    version: 0.1.3
 

--- a/shard.yml
+++ b/shard.yml
@@ -27,6 +27,8 @@ dependencies:
     github: crystal-lang/crystal-sqlite3
   scrypt:
     github: ysbaddaden/scrypt-crystal
+  humanhash:
+    github: kingsleyh/humanhash
 
 crystal: 0.27.0
 

--- a/spec/units/utils/chain_generator.cr
+++ b/spec/units/utils/chain_generator.cr
@@ -40,7 +40,7 @@ module ::Units::Utils::ChainGenerator
       @node = Sushi::Core::Node.new(true, true, "bind_host", 8008_i32, nil, nil, nil, nil, nil, @node_wallet, nil, false)
       @blockchain = @node.blockchain
       @blockchain.setup(@node)
-      @miner = {context: {address: miner_wallet.address, nonces: [] of UInt64}, socket: MockWebSocket.new}
+      @miner = {context: {address: miner_wallet.address, nonces: [] of UInt64}, socket: MockWebSocket.new, mid: "535061bddb0549f691c8b9c012a55ee2"}
       @transaction_factory = TransactionFactory.new(@node_wallet)
       @rpc = RPCController.new(@blockchain)
       @rest = RESTController.new(@blockchain)

--- a/src/core.cr
+++ b/src/core.cr
@@ -26,6 +26,7 @@ require "tokoroten"
 require "http/server"
 require "openssl/pkcs5"
 require "openssl/digest"
+require "humanhash"
 
 require "./common"
 require "./core/modules"

--- a/src/core/miner/miner.cr
+++ b/src/core/miner/miner.cr
@@ -14,6 +14,7 @@ module ::Sushi::Core
   class Miner < HandleSocket
     @wallet : Wallet
     @use_ssl : Bool
+    @mid : String = HumanHash.uuid.digest
 
     @workers : Array(Tokoroten::Worker) = [] of Tokoroten::Worker
 
@@ -52,6 +53,7 @@ module ::Sushi::Core
       send(socket, M_TYPE_MINER_HANDSHAKE, {
         version: Core::CORE_VERSION,
         address: @wallet.address,
+        mid: @mid
       })
 
       socket.run
@@ -95,7 +97,7 @@ module ::Sushi::Core
       block = _m_content.block
       difficulty = _m_content.difficulty
 
-      info "#{magenta("UPDATED BLOCK")}: #{light_green(block.index)} at chain difficulty: #{light_cyan(block.next_difficulty - 1)} with miner difficulty: #{light_cyan(difficulty)}"
+      info "#{magenta("MINED BLOCK")}: #{light_green(block.index)} at chain difficulty: #{light_cyan(block.next_difficulty - 1)} with miner difficulty: #{light_cyan(difficulty)}"
 
       debug "set difficulty: #{light_cyan(difficulty)}"
       debug "set block: #{light_green(block.index)}"

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -284,7 +284,7 @@ module ::Sushi::Core
 
     def broadcast_block(socket : HTTP::WebSocket, block : Block, from : Chord::NodeContext? = nil)
       if @blockchain.latest_index + 1 == block.index
-        info "new block coming: #{light_cyan(@blockchain.chain.size)}"
+        debug "new block coming: #{light_cyan(@blockchain.chain.size)}"
 
         if _block = @blockchain.valid_block?(block)
           new_block(_block)

--- a/src/core/protocol/protocol.cr
+++ b/src/core/protocol/protocol.cr
@@ -21,6 +21,7 @@ module ::Sushi::Core::Protocol
     JSON.mapping({
       version: Int32,
       address: String,
+      mid: String
     })
   end
 
@@ -46,7 +47,7 @@ module ::Sushi::Core::Protocol
 
   struct M_CONTENT_MINER_FOUND_NONCE
     JSON.mapping({
-      nonce: UInt64,
+      nonce: UInt64
     })
   end
 
@@ -55,7 +56,7 @@ module ::Sushi::Core::Protocol
   struct M_CONTENT_MINER_BLOCK_UPDATE
     JSON.mapping({
       block:      Block,
-      difficulty: Int32,
+      difficulty: Int32
     })
   end
 


### PR DESCRIPTION
This gives each miner a human readable hash using the humanhash library. The miner was previously distinguished only by the first 7 chars of the address is was using. However it's fairly common to use the same address for multiple miners and nodes so this provides an easier way to distinguish each miner.

### related issues
https://github.com/SushiChain/SushiChain/issues/230