### PR TITLE
Fix consensus difficulty when syncing

### DIFF
--- a/spec/units/blockchain/block.cr
+++ b/spec/units/blockchain/block.cr
@@ -74,8 +74,7 @@ describe Block do
         chain = block_factory.addBlocks(1).chain
         prev_hash = chain[1].to_hash
         timestamp = chain[1].timestamp
-        block = Block.new(2_i64, [a_fixed_coinbase_transaction], 68_u64, prev_hash, timestamp, 0_i32)
-        block.next_difficulty = 0
+        block = Block.new(2_i64, [a_fixed_coinbase_transaction], 68_u64, prev_hash, timestamp, 1_i32)
         block.valid_as_latest?(block_factory.blockchain, false).should be_true
       end
     end
@@ -178,9 +177,8 @@ describe Block do
         chain = block_factory.addBlocks(1).chain
         prev_hash = chain[1].to_hash
         timestamp = chain[1].timestamp
-        block = Block.new(2_i64, [a_fixed_coinbase_transaction], 68_u64, prev_hash, timestamp, 0_i32)
+        block = Block.new(2_i64, [a_fixed_coinbase_transaction], 68_u64, prev_hash, timestamp, 1_i32)
         block.merkle_tree_root = "invalid"
-        block.next_difficulty = 0
         expect_raises(Exception, "invalid merkle tree root (expected invalid but got d91329bca593bbae22fb70b7f450b4748002ac65)") do
           block.valid_as_latest?(block_factory.blockchain, false)
         end

--- a/src/core/blockchain/block.cr
+++ b/src/core/blockchain/block.cr
@@ -115,9 +115,12 @@ module ::Sushi::Core
               "(timestamp should be bigger than #{prev_timestamp} and smaller than #{next_timestamp})"
       end
 
-      if @next_difficulty != block_difficulty(@timestamp, (@timestamp - prev_timestamp), prev_block, blockchain.block_averages)
+      difficulty_for_block = block_difficulty(@timestamp, (@timestamp - prev_timestamp), prev_block, blockchain.block_averages)
+      difficulty_for_block = prev_block.index == 0 ? @next_difficulty : difficulty_for_block
+
+      if @next_difficulty != difficulty_for_block
         raise "next_difficulty is invalid " +
-              "(expected #{block_difficulty(@timestamp, (@timestamp - prev_timestamp), prev_block, blockchain.block_averages)} but got #{@next_difficulty})"
+              "(expected #{difficulty_for_block} but got #{@next_difficulty})"
       end
 
       merkle_tree_root = calcluate_merkle_tree_root

--- a/src/core/blockchain/consensus.cr
+++ b/src/core/blockchain/consensus.cr
@@ -55,9 +55,14 @@ module ::Sushi::Core::Consensus
     block_averages = block_averages.select { |a| a > 0_i64 }
     block_averages.delete_at(0) if block_averages.size > 0
 
-    debug "elapsed block time was: #{elapsed_block_time} secs"
+    debug "elapsed block time was: #{elapsed_block_time} secs between current block: #{block.index + 1} and previous block: #{block.index}"
 
-    block_average = block_averages.reduce { |a, b| a + b } / block_averages.size
+    block_average = begin
+      block_averages.reduce { |a, b| a + b } / block_averages.size
+    rescue
+      elapsed_block_time
+    end
+
     current_target = if block_averages.size < BLOCK_AVERAGE_LIMIT
                        debug "using elapsed block time as block averages: #{block_averages.size} is less than cache limit: #{BLOCK_AVERAGE_LIMIT}"
                        elapsed_block_time
@@ -78,8 +83,6 @@ module ::Sushi::Core::Consensus
       debug "maintaining block difficulty at '#{block.next_difficulty}' with block average: (#{block_average} secs)"
       block.next_difficulty
     end
-  rescue Enumerable::EmptyError
-    block.next_difficulty
   end
 
   include Hashes


### PR DESCRIPTION
Syncing from another chain had problems due to the timestamp diff between the genesis block: 0 and the first block timestamp. It was always the 1st block time instead of a useful diff duration - so the consensus was dropping the difficulty as the time exceeded the upper bound.