### PR TITLE
Sushi main program incorrectly specifies parser without knowing valid…

### DIFF
--- a/src/cli/sushi.cr
+++ b/src/cli/sushi.cr
@@ -57,9 +57,6 @@ module ::Sushi::Interface::Sushi
     end
 
     def option_parser
-      G.op.create_option_parser([
-        Options::JSON,
-      ])
     end
 
     def run_impl(action_name)


### PR DESCRIPTION
Sushi main program incorrectly specifies parser without knowing valid options

## Description
Removed sushi call to `create_option_parser` with incorrect options array.

## Related Issues
https://github.com/SushiChain/SushiChain/issues/251

