### PR TITLE
[WIP] #284 start of updated block rewards

### DIFF
--- a/spec/units/blockchain/block_reward_calculator.cr
+++ b/spec/units/blockchain/block_reward_calculator.cr
@@ -1,0 +1,36 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+require "./../../spec_helper"
+require "./../utils"
+
+include Units::Utils
+include Sushi::Core
+include Sushi::Core::TransactionModels
+include ::Sushi::Common::Denomination
+include Hashes
+
+MAX_BLOCKS      =  4_000_000_i64
+COIN_CAP        = 23_000_000_f32
+STARTING_REWARD =         12_f32
+
+describe BlockRewardCalculator do
+  it "should return the correct block reward based on the supplied index" do
+    calc = BlockRewardCalculator.new(STARTING_REWARD, COIN_CAP, MAX_BLOCKS)
+    count = 0_i64
+    (0_i64..MAX_BLOCKS).each do |i|
+      c = calc.reward_for_block(i, 0_i64)
+      count += c
+    end
+    p scale_decimal(count)
+  end
+end

--- a/spec/units/blockchain/block_reward_calculator.cr
+++ b/spec/units/blockchain/block_reward_calculator.cr
@@ -19,18 +19,28 @@ include Sushi::Core::TransactionModels
 include ::Sushi::Common::Denomination
 include Hashes
 
-MAX_BLOCKS      =  4_000_000_i64
-COIN_CAP        = 23_000_000_f32
-STARTING_REWARD =         12_f32
+MAX_BLOCKS      = 4_000_000_i64
+COIN_CAP        = BigDecimal.new(23_000_000)
+STARTING_REWARD = BigDecimal.new(12)
 
 describe BlockRewardCalculator do
-  it "should return the correct block reward based on the supplied index" do
-    calc = BlockRewardCalculator.new(STARTING_REWARD, COIN_CAP, MAX_BLOCKS)
-    count = 0_i64
-    (0_i64..MAX_BLOCKS).each do |i|
-      c = calc.reward_for_block(i, 0_i64)
-      count += c
-    end
-    p scale_decimal(count)
+  it "should return the correct block reward based on the supplied index with init" do
+    assert_calcs(BlockRewardCalculator.init)
   end
+
+  it "should return the correct block reward based on the supplied index" do
+    assert_calcs(BlockRewardCalculator.new(STARTING_REWARD, COIN_CAP, MAX_BLOCKS))
+  end
+
+  it "should return correct block reward when premine is supplied" do
+    calc = BlockRewardCalculator.init
+    calc.reward_for_block(1_i64, 0_i64).should eq(1199999373)
+  end
+end
+
+def assert_calcs(calc)
+  calc.reward_for_block(0_i64, 0_i64).should eq(1200000000)
+  calc.reward_for_block(1238291_i64, 0_i64).should eq(628924864)
+  calc.reward_for_block(756752_i64, 0_i64).should eq(808555726)
+  calc.reward_for_block(MAX_BLOCKS, 0_i64).should eq(0)
 end

--- a/spec/units/blockchain/rewards.cr
+++ b/spec/units/blockchain/rewards.cr
@@ -96,18 +96,18 @@ describe Blockchain do
   it "should take into account premine when allocating rewards" do
     with_factory do |block_factory, _|
       miner1 = {context: {address: "Miner 1", nonces: [1_u64, 2_u64] of UInt64}, socket: MockWebSocket.new, mid: "miner1"}
-      coinbase_amount = block_factory.blockchain.coinbase_amount(0, [] of Transaction, scale_i64("19000000"))
+      coinbase_amount = block_factory.blockchain.coinbase_amount(0, [] of Transaction, scale_i64("1000000"))
       transaction = block_factory.blockchain.create_coinbase_transaction(coinbase_amount, [miner1])
 
       node_reward = get_recipient_for(transaction.recipients, block_factory.node_wallet.address)[:amount]
       miner1_reward = get_recipient_for(transaction.recipients, "Miner 1")[:amount]
 
-      total_reward = 24123038_i64
+      total_reward = 1146356000_i64
 
-      node_reward.should eq(6030760_i64)
+      node_reward.should eq(286589000_i64)
       as_percentage(node_reward, total_reward).should eq(25)
 
-      miner1_reward.should eq(18092278_i64)
+      miner1_reward.should eq(859767000_i64)
       as_percentage(miner1_reward, total_reward).should eq(75)
 
       (node_reward + miner1_reward).should eq(total_reward)
@@ -117,7 +117,7 @@ describe Blockchain do
   it "should not allocate rewards if the total supply has been reached due to premine" do
     with_factory do |block_factory, _|
       miner1 = {context: {address: "Miner 1", nonces: [1_u64, 2_u64] of UInt64}, socket: MockWebSocket.new, mid: "miner1"}
-      coinbase_amount = block_factory.blockchain.coinbase_amount(0, [] of Transaction, scale_i64("20000000.00004113"))
+      coinbase_amount = block_factory.blockchain.coinbase_amount(0, [] of Transaction, scale_i64("19752020"))
       transaction = block_factory.blockchain.create_coinbase_transaction(coinbase_amount, [miner1])
       transaction.recipients.should be_empty
     end
@@ -129,7 +129,7 @@ describe Blockchain do
       transactions = [transaction_factory.make_send(2000_i64), transaction_factory.make_send(9000_i64)]
       total_reward = transactions.flat_map(&.senders).map(&.["fee"]).reduce(0) { |total, fee| total + fee }
 
-      coinbase_amount = block_factory.blockchain.coinbase_amount(TOTAL_BLOCK_LIMIT, transactions, 0_i64)
+      coinbase_amount = block_factory.blockchain.coinbase_amount(TOTAL_BLOCK_LIMIT + 1, transactions, 0_i64)
       transaction = block_factory.blockchain.create_coinbase_transaction(coinbase_amount, [miner1])
 
       node_reward = get_recipient_for(transaction.recipients, block_factory.node_wallet.address)[:amount]

--- a/spec/units/blockchain/rewards.cr
+++ b/spec/units/blockchain/rewards.cr
@@ -20,8 +20,9 @@ include ::Sushi::Common::Denomination
 include ::Sushi::Core::NodeComponents
 include Hashes
 
-TOTAL_BLOCK_REWARD = 50462650_i64
-TOTAL_BLOCK_LIMIT = 50462651_i64
+TOTAL_BLOCK_REWARD = 1200000000_i64
+TOTAL_BLOCK_LIMIT  =  4_000_000_i64
+
 
 describe Blockchain do
   it "should calculate the block rewards for a single miner" do
@@ -33,10 +34,10 @@ describe Blockchain do
       node_reward = get_recipient_for(transaction.recipients, block_factory.node_wallet.address)[:amount]
       miner1_reward = get_recipient_for(transaction.recipients, "Miner 1")[:amount]
 
-      node_reward.should eq(12615663_i64)
+      node_reward.should eq(300000000_i64)
       as_percentage(node_reward).should eq(25)
 
-      miner1_reward.should eq(37846987_i64)
+      miner1_reward.should eq(900000000_i64)
       as_percentage(miner1_reward).should eq(75)
 
       (node_reward + miner1_reward).should eq(TOTAL_BLOCK_REWARD)
@@ -56,16 +57,16 @@ describe Blockchain do
       miner2_reward = get_recipient_for(transaction.recipients, "Miner 2")[:amount]
       miner3_reward = get_recipient_for(transaction.recipients, "Miner 3")[:amount]
 
-      node_reward.should eq(12615664_i64)
+      node_reward.should eq(300000000_i64)
       as_percentage(node_reward).should eq(25)
 
-      miner1_reward.should eq(12615662_i64)
+      miner1_reward.should eq(300000000_i64)
       as_percentage(miner1_reward).should eq(25)
 
-      miner2_reward.should eq(12615662_i64)
+      miner2_reward.should eq(300000000_i64)
       as_percentage(miner2_reward).should eq(25)
 
-      miner3_reward.should eq(12615662_i64)
+      miner3_reward.should eq(300000000_i64)
       as_percentage(miner3_reward).should eq(25)
 
       (node_reward + miner1_reward + miner2_reward + miner3_reward).should eq(TOTAL_BLOCK_REWARD)
@@ -76,7 +77,7 @@ describe Blockchain do
     assert_reward_distribution(1, 2, 25, 50)
     assert_reward_distribution(1, 3, 19, 56)
     assert_reward_distribution(1, 4, 15, 60)
-    assert_reward_distribution(1, 5, 12, 62)
+    assert_reward_distribution(1, 5, 13, 63)
     assert_reward_distribution(1, 6, 11, 64)
     assert_reward_distribution(1, 7, 9, 66)
     assert_reward_distribution(1, 70, 1, 74)
@@ -126,7 +127,7 @@ describe Blockchain do
     with_factory do |block_factory, transaction_factory|
       miner1 = {context: {address: "Miner 1", nonces: [1_u64, 2_u64] of UInt64}, socket: MockWebSocket.new, mid: "miner1"}
       transactions = [transaction_factory.make_send(2000_i64), transaction_factory.make_send(9000_i64)]
-      total_reward = transactions.flat_map(&.senders).map(&.["fee"]).reduce(0){|total, fee| total + fee}
+      total_reward = transactions.flat_map(&.senders).map(&.["fee"]).reduce(0) { |total, fee| total + fee }
 
       coinbase_amount = block_factory.blockchain.coinbase_amount(TOTAL_BLOCK_LIMIT, transactions, 0_i64)
       transaction = block_factory.blockchain.create_coinbase_transaction(coinbase_amount, [miner1])

--- a/spec/units/blockchain/supply.cr
+++ b/spec/units/blockchain/supply.cr
@@ -20,26 +20,32 @@ include ::Sushi::Common::Denomination
 include Hashes
 
 describe Blockchain do
+  it "aa" do
+    with_factory do |block_factory, _|
+      p block_factory.blockchain.coinbase_amount(756752_i64, [] of Transaction, 0_i64)
+    end
+  end
+
   it "should calculate the total supply" do
     with_factory do |block_factory, _|
       t_amount = 0_i64
-      c_amount = 0_i64
+      # c_amount = 0_i64
       i = 0_i64
 
       loop do
         c_amount = block_factory.blockchain.coinbase_amount(i, [] of Transaction, 0_i64)
-        break if c_amount == 0
+        break if c_amount == 0_i64
 
         t_amount += c_amount
         i += 1
-        # puts "at #{i} (current amount: #{c_amount}, total amount: #{scale_decimal(t_amount)} [SUSHI])\r" if i % 1000000 == 0
+        # puts "at #{i} (current amount: #{c_amount}, total amount: #{scale_decimal(t_amount)} [SUSHI])\r"
       end
 
       # puts ""
       # puts "Total amount : #{scale_decimal(t_amount)} [SUSHI]"
       # puts "Last index   : #{i}"
 
-      i.should eq(50462651_i64)                              # last index
+      i.should eq(756752_i64)                                # last index
       scale_decimal(t_amount).should eq("20000000.00004112") # total supply
     end
   end

--- a/src/common/modules/denomination.cr
+++ b/src/common/modules/denomination.cr
@@ -17,6 +17,10 @@ module ::Sushi::Common::Denomination
     BigDecimal.new(value).scale_to(BigDecimal.new(1, SCALE_DECIMAL)).value.to_i64
   end
 
+  def scale_i64(value : BigDecimal) : Int64
+    value.scale_to(BigDecimal.new(1, SCALE_DECIMAL)).value.to_i64
+  end
+
   def scale_decimal(value : Int64) : String
     BigDecimal.new(value, 8).to_s
   end

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -360,22 +360,22 @@ module ::Sushi::Core
       # return total_fees(transactions) if index_index > RR
       # Math.sqrt(RR - index_index).to_i64
       return total_fees(transactions) if index > @block_reward_calculator.max_blocks
-      @block_reward_calculator.reward_for_block(index)
+      @block_reward_calculator.reward_for_block(index, premine_total_value)
     end
 
-    def premine_as_index(premine_value : Int64, current_index : Int64) : Int64
-      return 0_i64 if (premine_value <= 0_i64 || current_index > 0)
-      accumulated_value = 0_i64
-      index = 0_i64
-      (0_i64..(Math.sqrt(RR).to_i64)).each do |_|
-        value = Math.sqrt(RR - (index * index)).to_i64
-        accumulated_value = accumulated_value + value
-        break if accumulated_value >= premine_value
-        index = index + 1
-      end
-      debug "accumulated_value: #{accumulated_value} -> premine_value: #{premine_value}, index: #{index}"
-      index
-    end
+    # def premine_as_index(premine_value : Int64, current_index : Int64) : Int64
+    #   return 0_i64 if (premine_value <= 0_i64 || current_index > 0)
+    #   accumulated_value = 0_i64
+    #   index = 0_i64
+    #   (0_i64..(Math.sqrt(RR).to_i64)).each do |_|
+    #     value = Math.sqrt(RR - (index * index)).to_i64
+    #     accumulated_value = accumulated_value + value
+    #     break if accumulated_value >= premine_value
+    #     index = index + 1
+    #   end
+    #   debug "accumulated_value: #{accumulated_value} -> premine_value: #{premine_value}, index: #{index}"
+    #   index
+    # end
 
     def total_fees(transactions) : Int64
       return 0_i64 if transactions.size < 2

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -18,6 +18,7 @@ module ::Sushi::Core
   class Blockchain
     TOKEN_DEFAULT = Core::DApps::BuildIn::UTXO::DEFAULT
 
+
     alias Chain = Array(Block)
     alias Header = NamedTuple(
       index: Int64,
@@ -33,10 +34,10 @@ module ::Sushi::Core
 
     @node : Node?
     @mining_block : Block?
+    @block_reward_calculator : BlockRewardCalculator = BlockRewardCalculator.init
 
     def initialize(@wallet : Wallet, @database : Database?, @premine : Premine?)
       initialize_dapps
-
       TransactionPool.setup
     end
 
@@ -351,13 +352,15 @@ module ::Sushi::Core
       )
     end
 
-    RR = 2546479089470325
+    # RR = 2546479089470325
 
     def coinbase_amount(index : Int64, transactions, premine_total_value : Int64) : Int64
-      premine_index = premine_as_index(premine_total_value, index)
-      index_index = (premine_index + index) * (premine_index + index)
-      return total_fees(transactions) if index_index > RR
-      Math.sqrt(RR - index_index).to_i64
+      # premine_index = premine_as_index(premine_total_value, index)
+      # index_index = (premine_index + index) * (premine_index + index)
+      # return total_fees(transactions) if index_index > RR
+      # Math.sqrt(RR - index_index).to_i64
+      return total_fees(transactions) if index > @block_reward_calculator.max_blocks
+      @block_reward_calculator.reward_for_block(index)
     end
 
     def premine_as_index(premine_value : Int64, current_index : Int64) : Int64

--- a/src/core/blockchain/block_reward_calculator.cr
+++ b/src/core/blockchain/block_reward_calculator.cr
@@ -12,21 +12,21 @@
 
 module ::Sushi::Core
   struct BlockRewardCalculator
-    getter exponential : Float32
+    getter exponential : BigDecimal
     getter max_blocks : Int64
 
-    def initialize(@first_block_reward : Float32, @total_reward : Float32, @max_blocks : Int64)
+    def initialize(@first_block_reward : BigDecimal, @total_reward : BigDecimal, @max_blocks : Int64)
       @exponential = 1 - @first_block_reward / @total_reward
     end
 
     def reward_for_block(block_index : Int64, total_premine_value : Int64)
-      premine_index = premine_as_index(total_premine_value, block_index)
+      p premine_index = premine_as_index(total_premine_value, block_index)
       get_block_reward(block_index + premine_index)
     end
 
     private def get_block_reward(block_index : Int64)
       return 0_i64 if block_index >= @max_blocks
-      scale_i64((@first_block_reward * (@exponential ** block_index)).to_s)
+      scale_i64((@first_block_reward * (BigDecimal.new(@exponential.to_f64 ** block_index))))
     end
 
     private def premine_as_index(premine_value : Int64, current_index : Int64) : Int64
@@ -44,9 +44,9 @@ module ::Sushi::Core
     end
 
     def self.init
-      BlockRewardCalculator.new(12, 23_000_000, 4_000_000_i64)
+      BlockRewardCalculator.new(BigDecimal.new(12), BigDecimal.new(23_000_000), 4_000_000_i64)
     end
-  end
 
-  include Logger
+    include Logger
+  end
 end

--- a/src/core/blockchain/block_reward_calculator.cr
+++ b/src/core/blockchain/block_reward_calculator.cr
@@ -1,0 +1,31 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+struct BlockRewardCalculator
+
+  getter exponential : Float32
+  getter max_blocks : Int64
+
+  def initialize(@first_block_reward : Float32, @total_reward : Float32, @max_blocks : Int64)
+    @exponential = 1 - @first_block_reward / @total_reward
+  end
+
+  def reward_for_block(block_index : Int64)
+   return 0_i64 if block_index >= @max_blocks
+   scale_i64((@first_block_reward * (@exponential ** block_index)).to_s)
+  end
+
+  def self.init
+    BlockRewardCalculator.new(12, 23_000_000, 4_000_000_i64)
+  end
+
+end

--- a/src/core/blockchain/block_reward_calculator.cr
+++ b/src/core/blockchain/block_reward_calculator.cr
@@ -10,22 +10,43 @@
 #
 # Removal or modification of this copyright notice is prohibited.
 
-struct BlockRewardCalculator
+module ::Sushi::Core
+  struct BlockRewardCalculator
+    getter exponential : Float32
+    getter max_blocks : Int64
 
-  getter exponential : Float32
-  getter max_blocks : Int64
+    def initialize(@first_block_reward : Float32, @total_reward : Float32, @max_blocks : Int64)
+      @exponential = 1 - @first_block_reward / @total_reward
+    end
 
-  def initialize(@first_block_reward : Float32, @total_reward : Float32, @max_blocks : Int64)
-    @exponential = 1 - @first_block_reward / @total_reward
+    def reward_for_block(block_index : Int64, total_premine_value : Int64)
+      premine_index = premine_as_index(total_premine_value, block_index)
+      get_block_reward(block_index + premine_index)
+    end
+
+    private def get_block_reward(block_index : Int64)
+      return 0_i64 if block_index >= @max_blocks
+      scale_i64((@first_block_reward * (@exponential ** block_index)).to_s)
+    end
+
+    private def premine_as_index(premine_value : Int64, current_index : Int64) : Int64
+      return 0_i64 if (premine_value <= 0_i64 || current_index > 0)
+      accumulated_value = 0_i64
+      index = 0_i64
+      (0_i64..@max_blocks).each do |_|
+        value = get_block_reward(index)
+        accumulated_value += value
+        break if accumulated_value >= premine_value
+        index += 1
+      end
+      debug "accumulated_value: #{accumulated_value} -> premine_value: #{premine_value}, index: #{index}"
+      index
+    end
+
+    def self.init
+      BlockRewardCalculator.new(12, 23_000_000, 4_000_000_i64)
+    end
   end
 
-  def reward_for_block(block_index : Int64)
-   return 0_i64 if block_index >= @max_blocks
-   scale_i64((@first_block_reward * (@exponential ** block_index)).to_s)
-  end
-
-  def self.init
-    BlockRewardCalculator.new(12, 23_000_000, 4_000_000_i64)
-  end
-
+  include Logger
 end


### PR DESCRIPTION
Our current block rewards are too little for the rate of blocks mined and would mean we would not reach the cap for about 86 years. 

This implements an exponentially decreasing curve for block rewards based on a geometric series as follows:

```
12.0 : 0 - 79323 (79324)
11.0 : 79324 - 248877 (169554)
10.0 : 248878 - 435415 (186538)
9.0 : 435416 - 642719 (207304)
8.0 : 642720 - 875999 (233280)
7.0 : 876000 - 1142713 (266714)
6.0 : 1142714 - 1454071 (311358)
5.0 : 1454072 - 1828084 (374013)
4.0 : 1828085 - 2296488 (468404)
3.0 : 2296489 - 2923610 (627122)
2.0 : 2923611 - 3875695 (952085)
1.0 : 3875696 - 3999999 (124304)
0.0 : 4000000 - 4000000 (1)
amount / block start - block end  / number blocks
```
This is a cap of 4_000_000 blocks and approx 23_000_000 SUSHI coins and would mine blocks for about 15 years (based on 720 blocks per day)