### PR TITLE
Bintray publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,9 @@ jobs:
     steps:
       - checkout
       - run: |
+          apt-get update
+          apt-get install curl libsqlite3-dev -y
+      - run: |
           shards build --release
           tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUMBER}.tar.gz bin/sushi bin/sushid bin/sushim
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,8 +79,8 @@ jobs:
           apt-get install curl libsqlite3-dev -y
       - run: |
           shards build --release
-          tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUMBER}.tar.gz bin/sushi bin/sushid bin/sushim
-          cp Sushi-0.0.${CIRCLE_BUILD_NUMBER}.tar.gz $CIRCLE_ARTIFACTS
+          tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz bin/sushi bin/sushid bin/sushim
+          cp Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz $CIRCLE_ARTIFACTS
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,12 +76,10 @@ jobs:
       - checkout
       - run: |
           apt-get update
-          apt-get install curl libsqlite3-dev -y
+          apt-get install curl -y
       - run: |
           shards build --release
-          tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz bin/sushi bin/sushid bin/sushim
-      - store_artifacts:
-          path: Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz
+          ./publish-bintray.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,15 @@ jobs:
           docker build -t sushichain/sushid .
           docker push sushichain/sushid
 
+  publish-bintray:
+    docker:
+      - image: crystallang/crystal:0.30.1
+    steps:
+      - checkout
+      - run: |
+          shards build --release
+          tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUMBER}.tar.gz bin/sushi bin/sushid bin/sushim
+
 workflows:
   version: 2
 
@@ -90,3 +99,4 @@ workflows:
           filters:
             branches:
               only: master
+      - publish-bintray

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
       - checkout
       - run: |
           apt-get update
-          apt-get install curl -y
+          apt-get install curl libsqlite3-dev -y
       - run: |
           shards build --release
           ./publish-bintray.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
           shards build --release
           tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz bin/sushi bin/sushid bin/sushim
       - store_artifacts:
-          path: Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz $CIRCLE_ARTIFACTS
+          path: Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,8 @@ jobs:
       - run: |
           shards build --release
           tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz bin/sushi bin/sushid bin/sushim
-          cp Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz $CIRCLE_ARTIFACTS
+      - store_artifacts:
+          path: Sushi-0.0.${CIRCLE_BUILD_NUM}.tar.gz $CIRCLE_ARTIFACTS
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,7 @@ jobs:
       - run: |
           shards build --release
           tar cvzf Sushi-0.0.${CIRCLE_BUILD_NUMBER}.tar.gz bin/sushi bin/sushid bin/sushim
+          cp Sushi-0.0.${CIRCLE_BUILD_NUMBER}.tar.gz $CIRCLE_ARTIFACTS
 
 workflows:
   version: 2

--- a/publish-bintray.sh
+++ b/publish-bintray.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+version=0.0.${CIRCLE_BUILD_NUM}
+file=Sushi-${version}.tar.gz
+
+function create_package {
+  tar cvzf ${file} bin/sushi bin/sushid bin/sushim
+}
+
+function main {
+  credentials=raymanoz:${BINTRAY_API_KEY}
+  package=https://api.bintray.com/content/raymanoz/SushiChain/SushiChain
+
+  echo "Uploading ${version}..."
+  curl -T ${file} -u${credentials} ${package}/${version}/${file}
+
+  echo 
+  echo "Publishing ${version}..."
+  curl -X POST -u${credentials} ${package}/${version}/publish
+}
+
+create_package
+main


### PR DESCRIPTION
## Description
Added automated publish to bintray. This publishes the 3 binaries (sushi, sushid, sushim) in a tar.gz file.

## Related Issues
https://github.com/SushiChain/SushiChain/issues/248

## Some stuff to think about
- [ ] location of publish script
- [ ] version numbering. It is kind of hard-coded in the publish script
- [ ] see if it is possible to push to an organisation repo on bintray. Currently pushing to my own account (raymanoz).

