### PR TITLE
Convert dApps to use the database rather than the in-memory chain

### DIFF
--- a/dapps/dapp.cr
+++ b/dapps/dapp.cr
@@ -274,6 +274,7 @@ module ::Sushi::Core::DApps::User
     @latest_loaded_block_index = 0
 
     def record(chain : Blockchain::Chain)
+      #TODO - replace this with fetch from db
       return if chain.size < @latest_loaded_block_index
 
       chain[@latest_loaded_block_index..-1].each do |block|

--- a/spec/units/blockchain/blockchain.cr
+++ b/spec/units/blockchain/blockchain.cr
@@ -311,17 +311,6 @@ describe Blockchain do
     end
   end
 
-  describe "headers" do
-    it "should return the headers" do
-      with_factory do |block_factory|
-        block_factory.add_slow_blocks(3).add_fast_blocks(4)
-        blockchain = block_factory.blockchain
-        header_indexes = blockchain.headers.map(&.["index"])
-        header_indexes.should eq([0, 1, 2, 3, 4, 5, 6, 7])
-      end
-    end
-  end
-
   describe "transactions_for_address" do
     it "should return all transactions for address" do
       with_factory do |block_factory, transaction_factory|

--- a/spec/units/blockchain/blockchain.cr
+++ b/spec/units/blockchain/blockchain.cr
@@ -156,7 +156,7 @@ describe Blockchain do
         block_factory.add_slow_blocks(2)
         blockchain.pending_slow_transactions.size.should eq(0)
         blockchain.embedded_slow_transactions.size.should eq(0)
-        blockchain.rejects.find(transaction.id).should eq("the transaction #{transaction.id} is already included in 2")
+        blockchain.rejects.find(transaction.id).should eq("the transaction #{transaction.id} is already included in block: 2")
       end
     end
   end

--- a/spec/units/dapps/blockchain_info.cr
+++ b/spec/units/dapps/blockchain_info.cr
@@ -184,7 +184,6 @@ describe BlockchainInfo do
           json = JSON.parse(payload)
 
           with_rpc_exec_internal_post(block_factory.rpc, json) do |result|
-            block_index = block_factory.chain.select { |blk| blk.transactions.map { |txn| txn.id }.includes?(transaction_id) }.first.index # ameba:disable Performance/FirstLastAfterFilter
             unless expected_block_header = block_factory.database.get_block_for_transaction(transaction_id)
               fail "no block found for transaction id #{transaction_id}"
             end

--- a/spec/units/dapps/indices.cr
+++ b/spec/units/dapps/indices.cr
@@ -67,6 +67,7 @@ describe Indices do
       it "should not be valid if already in the chain" do
         with_factory do |block_factory, _|
           indices = Indices.new(block_factory.blockchain)
+          chain = block_factory.add_slow_blocks(2).chain
           transaction = chain.last.transactions.first
 
           expect_raises(Exception, "the transaction #{transaction.id} is already included in block: 4") do

--- a/spec/units/dapps/scars.cr
+++ b/spec/units/dapps/scars.cr
@@ -562,35 +562,6 @@ describe Scars do
       end
     end
 
-    describe "#record" do
-      it "should record internal domains" do
-        with_factory do |block_factory, transaction_factory|
-          chain = block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform("domain.sc", 0_i64)]).add_slow_blocks(10).chain
-          scars = Scars.new(block_factory.blockchain)
-          scars.record(chain)
-          expected = [{"domain.sc" => {domain_name: "domain.sc", address: transaction_factory.sender_wallet.address, status: Status::ACQUIRED, price: 0_i64}}]
-          # scars.@domains_internal.reject!(&.empty?).should eq(expected)
-          fail "fix me"
-        end
-      end
-    end
-
-    describe "#clear" do
-      it "should clear internal domains" do
-        with_factory do |block_factory, transaction_factory|
-          chain = block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform("domain.sc", 0_i64)]).add_slow_blocks(10).chain
-          scars = Scars.new(block_factory.blockchain)
-          scars.record(chain)
-          expected = [{"domain.sc" => {domain_name: "domain.sc", address: transaction_factory.sender_wallet.address, status: Status::ACQUIRED, price: 0_i64}}]
-          # scars.@domains_internal.reject!(&.empty?).should eq(expected)
-          fail "fix me"
-          scars.clear
-          # scars.@domains_internal.size.should eq(0)
-          fail "fix me"
-        end
-      end
-    end
-
     describe "#Scars.fee" do
       it "should show the fee for an action" do
         Scars.fee("scars_buy").should eq(100000_i64)

--- a/spec/units/dapps/scars.cr
+++ b/spec/units/dapps/scars.cr
@@ -568,8 +568,9 @@ describe Scars do
           chain = block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform("domain.sc", 0_i64)]).add_slow_blocks(10).chain
           scars = Scars.new(block_factory.blockchain)
           scars.record(chain)
-          expected = [{"domain.sc" => {domain_name: "domain.sc", address: transaction_factory.sender_wallet.address, status: 0, price: 0_i64}}]
-          scars.@domains_internal.reject!(&.empty?).should eq(expected)
+          expected = [{"domain.sc" => {domain_name: "domain.sc", address: transaction_factory.sender_wallet.address, status: Status::ACQUIRED, price: 0_i64}}]
+          # scars.@domains_internal.reject!(&.empty?).should eq(expected)
+          fail "fix me"
         end
       end
     end
@@ -580,10 +581,12 @@ describe Scars do
           chain = block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform("domain.sc", 0_i64)]).add_slow_blocks(10).chain
           scars = Scars.new(block_factory.blockchain)
           scars.record(chain)
-          expected = [{"domain.sc" => {domain_name: "domain.sc", address: transaction_factory.sender_wallet.address, status: 0, price: 0_i64}}]
-          scars.@domains_internal.reject!(&.empty?).should eq(expected)
+          expected = [{"domain.sc" => {domain_name: "domain.sc", address: transaction_factory.sender_wallet.address, status: Status::ACQUIRED, price: 0_i64}}]
+          # scars.@domains_internal.reject!(&.empty?).should eq(expected)
+          fail "fix me"
           scars.clear
-          scars.@domains_internal.size.should eq(0)
+          # scars.@domains_internal.size.should eq(0)
+          fail "fix me"
         end
       end
     end

--- a/spec/units/dapps/scars.cr
+++ b/spec/units/dapps/scars.cr
@@ -605,7 +605,7 @@ describe Scars do
       end
     end
 
-    describe "#sales" do
+    describe "#scars_for_sale_impl" do
       it "should list all the domains that are for sale" do
         with_factory do |block_factory, transaction_factory|
           domain = "domain1.sc"
@@ -617,7 +617,7 @@ describe Scars do
           scars = Scars.new(block_factory.blockchain)
           scars.record(chain)
 
-          sales = scars.sales
+          sales = scars.scars_for_sale_impl
           sales.size.should eq(1)
 
           result = sales.first
@@ -631,7 +631,7 @@ describe Scars do
       it "should return empty list when no domains are for sale" do
         with_factory do |block_factory, _|
           scars = Scars.new(block_factory.blockchain)
-          scars.sales.size.should eq(0)
+          scars.scars_for_sale_impl.size.should eq(0)
         end
       end
     end

--- a/spec/units/dapps/scars.cr
+++ b/spec/units/dapps/scars.cr
@@ -25,7 +25,7 @@ describe Scars do
         scars = Scars.new(block_factory.blockchain)
         scars.record(chain)
         wallet = Wallet.from_json(Wallet.create(true).to_json)
-        scars.lookup(wallet.address).should eq [] of Array(Sushi::Core::DApps::BuildIn::Scars::Domain)
+        scars.lookup(wallet.address).should eq [] of Array(Domain)
       end
     end
 
@@ -75,7 +75,7 @@ describe Scars do
         on_success(scars.resolve(domain, 1)) do |result|
           result["domain_name"].should eq(domain)
           result["address"].should eq(transaction_factory.sender_wallet.address)
-          result["status"].should eq(0)
+          result["status"].should eq(Status::ACQUIRED)
           result["price"].should eq(0_i64)
         end
       end
@@ -102,7 +102,7 @@ describe Scars do
           on_success(scars.resolve_pending(domain, transactions)) do |result|
             result["domain_name"].should eq(domain)
             result["address"].should eq(transaction_factory.sender_wallet.address)
-            result["status"].should eq(0)
+            result["status"].should eq(Status::ACQUIRED)
             result["price"].should eq(0_i64)
           end
         end
@@ -620,7 +620,7 @@ describe Scars do
           result = sales.first
           result["domain_name"].should eq(domain)
           result["address"].should eq(transaction_factory.sender_wallet.address)
-          result["status"].should eq(1)
+          result["status"].should eq(Status::FOR_SALE)
           result["price"].should eq("0.000005")
         end
       end

--- a/spec/units/dapps/token.cr
+++ b/spec/units/dapps/token.cr
@@ -129,6 +129,7 @@ describe Token do
         chain = block_factory.add_slow_block([transaction1]).add_slow_blocks(10).chain
         token = Token.new(block_factory.blockchain)
         token.record(chain)
+
         expect_raises(Exception, "the token KINGS is already created") do
           token.valid_transaction?(transaction2, [] of Transaction)
         end
@@ -184,22 +185,14 @@ describe Token do
     end
   end
 
-  it "should #record a chain" do
-    with_factory do |block_factory, _|
-      chain = block_factory.add_slow_blocks(10).chain
+  it "#record create any new tokens" do
+    with_factory do |block_factory, transaction_factory|
+      token_name = "NEW"
+      transaction = transaction_factory.make_create_token(token_name, 10_i64)
+      chain = block_factory.add_slow_blocks(10).add_slow_block([transaction]).chain
       token = Token.new(block_factory.blockchain)
-      token.record(chain).size.should eq(11)
-    end
-  end
-
-  it "should #clear correctly" do
-    with_factory do |block_factory, _|
-      chain = block_factory.add_slow_blocks(10).chain
-      token = Token.new(block_factory.blockchain)
-      token.record(chain).size.should eq(11)
-      token.clear
-      token.@recorded_indices.size.should eq(0)
-      token.@tokens.should eq(["SUSHI"])
+      token.record(chain)
+      block_factory.database.token_exists?(token_name).should be_true
     end
   end
 

--- a/spec/units/dapps/utxo.cr
+++ b/spec/units/dapps/utxo.cr
@@ -59,14 +59,10 @@ describe UTXO do
 
         blockchain = block_factory.add_slow_block(false).blockchain
 
-        # utxo = UTXO.new(blockchain)
-        #
         block_factory.add_slow_block(transactions1)
           .add_slow_block(transactions2)
           .add_slow_block(transactions3)
 
-        # utxo.record(chain)
-        #
         _utxo = blockchain.utxo.@utxo_internal
         _utxo.size.should eq(11)
 

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -332,8 +332,8 @@ describe RESTController do
         address = transaction_factory.sender_wallet.address
         transaction = transaction_factory.make_send(100_i64)
         block_factory.add_slow_block([transaction]).add_slow_blocks(2)
-        exec_rest_api(block_factory.rest.__v1_address_transactions(context("/api/v1/address/#{address}/transactions?actions=send"), {address: address, actions: "send"})) do |result|  
-        result["status"].to_s.should eq("success")
+        exec_rest_api(block_factory.rest.__v1_address_transactions(context("/api/v1/address/#{address}/transactions?actions=send"), {address: address, actions: "send"})) do |result|
+          result["status"].to_s.should eq("success")
           transactions = Array(Transaction).from_json(result["result"].to_json)
           transactions.map { |txn| txn.action }.uniq.should eq(["send"])
         end

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -496,8 +496,8 @@ describe RESTController do
       with_factory do |block_factory, transaction_factory|
         domain = "sushi.sc"
         block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform(domain, 0_i64)]).add_slow_blocks(2).add_slow_block([transaction_factory.make_sell_domain(domain, 1_i64)]).add_slow_blocks(3)
+        
         exec_rest_api(block_factory.rest.__v1_scars_sales(context("/api/v1/scars/sales"), no_params)) do |result|
-          pp result
           result["status"].to_s.should eq("success")
           result = Array(DomainResult).from_json(result["result"].to_json).first
           result.domain_name.should eq(domain)

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -496,7 +496,7 @@ describe RESTController do
       with_factory do |block_factory, transaction_factory|
         domain = "sushi.sc"
         block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform(domain, 0_i64)]).add_slow_blocks(2).add_slow_block([transaction_factory.make_sell_domain(domain, 1_i64)]).add_slow_blocks(3)
-        
+
         exec_rest_api(block_factory.rest.__v1_scars_sales(context("/api/v1/scars/sales"), no_params)) do |result|
           result["status"].to_s.should eq("success")
           result = Array(DomainResult).from_json(result["result"].to_json).first

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -17,49 +17,71 @@ include Units::Utils
 include Sushi::Core::Controllers
 include Sushi::Core::Keys
 
+private def asset_blockchain(api_path)
+  with_factory do |block_factory, _|
+    block_factory.add_slow_blocks(50)
+    exec_rest_api(block_factory.rest.__v1_blockchain(context(api_path), no_params)) do |result|
+      result["status"].to_s.should eq("success")
+      yield result["result"]
+    end
+  end
+end
+
+private def asset_blockchain_header(api_path)
+  with_factory do |block_factory, _|
+    block_factory.add_slow_blocks(50)
+    exec_rest_api(block_factory.rest.__v1_blockchain_header(context(api_path), no_params)) do |result|
+      result["status"].to_s.should eq("success")
+      yield result["result"]
+    end
+  end
+end
 
 describe RESTController do
   describe "__v1_blockchain" do
     it "should return the full blockchain with pagination defaults (page:0,per_page:20,direction:asc)" do
-      with_factory do |block_factory, _|
-        block_factory.add_slow_blocks(500)
-        exec_rest_api(block_factory.rest.__v1_blockchain(context("/api/v1/blockchain"), no_params)) do |result|
-          result["status"].to_s.should eq("success")
-          blocks = Array(SlowBlock).from_json(result["result"].to_json)
-          blocks.size.should eq(20)
-          blocks.first.index.should eq(0)
-        end
+      asset_blockchain("/api/v1/blockchain") do |result|
+        blocks = Array(SlowBlock).from_json(result.to_json)
+        blocks.size.should eq(20)
+        blocks.first.index.should eq(0)
       end
     end
-    # it "should return the full blockchain with pagination options" do
-    #   with_factory do |block_factory, _|
-    #     block_factory.add_slow_blocks(500)
-    #     exec_rest_api(block_factory.rest.__v1_blockchain(context("/api/v1/blockchain"), no_params)) do |result|
-    #       result["status"].to_s.should eq("success")
-    #       Array(SlowBlock).from_json(result["result"].to_json).size.should eq(blocks_to_add + 1)
-    #     end
-    #   end
-    # end
+    it "should return the full blockchain with pagination specified direction (page:0,per_page:20,direction:desc)" do
+      asset_blockchain("/api/v1/blockchain?direction=down") do |result|
+        blocks = Array(SlowBlock).from_json(result.to_json)
+        blocks.size.should eq(20)
+        blocks.first.index.should eq(100)
+      end
+    end
+    it "should return the full blockchain with pagination specified direction (page:2,per_page:1,direction:desc)" do
+      asset_blockchain("/api/v1/blockchain?page=2&per_page=1&direction=down") do |result|
+        blocks = Array(SlowBlock).from_json(result.to_json)
+        blocks.size.should eq(1)
+        blocks.first.index.should eq(96)
+      end
+    end
   end
 
   describe "__v1_blockchain_header" do
-    it "should return the only blockchain headers when full chain fits into memory" do
-      with_factory do |block_factory, _|
-        block_factory.add_slow_blocks(2)
-        exec_rest_api(block_factory.rest.__v1_blockchain_header(context("/api/v1/blockchain/header"), no_params)) do |result|
-          result["status"].to_s.should eq("success")
-          Array(Blockchain::SlowHeader).from_json(result["result"].to_json).size.should eq(3)
-        end
+    it "should return the blockchain headers with pagination defaults (page:0,per_page:20,direction:asc)" do
+      asset_blockchain_header("/api/v1/blockchain/header") do |result|
+        blocks = Array(Blockchain::SlowHeader).from_json(result.to_json)
+        blocks.size.should eq(20)
+        blocks.first[:index].should eq(0)
       end
     end
-    it "should return the only blockchain headers when full chain is bigger than memory"  do
-      with_factory do |block_factory, _|
-        blocks_to_add = block_factory.blocks_to_hold + 8
-        block_factory.add_slow_blocks(blocks_to_add)
-        exec_rest_api(block_factory.rest.__v1_blockchain_header(context("/api/v1/blockchain/header"), no_params)) do |result|
-          result["status"].to_s.should eq("success")
-          Array(Blockchain::SlowHeader).from_json(result["result"].to_json).size.should eq(blocks_to_add + 1)
-        end
+    it "should return the blockchain headers with pagination specified direction (page:0,per_page:20,direction:desc)" do
+      asset_blockchain_header("/api/v1/blockchain/header/?direction=down") do |result|
+        blocks = Array(Blockchain::SlowHeader).from_json(result.to_json)
+        blocks.size.should eq(20)
+        blocks.first[:index].should eq(100)
+      end
+    end
+    it "should return the blockchain headers with pagination specified direction (page:2,per_page:1,direction:desc)" do
+      asset_blockchain_header("/api/v1/blockchain/header?page=2&per_page=1&direction=down") do |result|
+        blocks = Array(Blockchain::SlowHeader).from_json(result.to_json)
+        blocks.size.should eq(1)
+        blocks.first[:index].should eq(96)
       end
     end
   end
@@ -101,7 +123,7 @@ describe RESTController do
         block_factory.add_slow_blocks(2)
         exec_rest_api(block_factory.rest.__v1_block_index(context("/api/v1/block/99"), {index: 99})) do |result|
           result["status"].to_s.should eq("error")
-          result["reason"].should eq("invalid index 99 (blockchain latest index is 4)")
+          result["reason"].should eq("failed to find a block for the index: 99")
         end
       end
     end
@@ -122,7 +144,7 @@ describe RESTController do
         block_factory.add_slow_blocks(2)
         exec_rest_api(block_factory.rest.__v1_block_index_header(context("/api/v1/block/99/header"), {index: 99})) do |result|
           result["status"].to_s.should eq("error")
-          result["reason"].should eq("invalid index 99 (blockchain latest index is 4)")
+          result["reason"].should eq("failed to find a block for the index: 99")
         end
       end
     end
@@ -135,15 +157,6 @@ describe RESTController do
         exec_rest_api(block_factory.rest.__v1_block_index_transactions(context("/api/v1/block/0/header"), {index: 0})) do |result|
           result["status"].to_s.should eq("success")
           Array(Transaction).from_json(result["result"].to_json)
-        end
-      end
-    end
-    it "should return failure when block index is invalid" do
-      with_factory do |block_factory, _|
-        block_factory.add_slow_blocks(2)
-        exec_rest_api(block_factory.rest.__v1_block_index_transactions(context("/api/v1/block/99/header"), {index: 99})) do |result|
-          result["status"].to_s.should eq("error")
-          result["reason"].should eq("invalid index 99 (blockchain latest index is 4)")
         end
       end
     end
@@ -319,8 +332,8 @@ describe RESTController do
         address = transaction_factory.sender_wallet.address
         transaction = transaction_factory.make_send(100_i64)
         block_factory.add_slow_block([transaction]).add_slow_blocks(2)
-        exec_rest_api(block_factory.rest.__v1_address_transactions(context("/api/v1/address/#{address}/transactions?actions=send"), {address: address, actions: "send"})) do |result|
-          result["status"].to_s.should eq("success")
+        exec_rest_api(block_factory.rest.__v1_address_transactions(context("/api/v1/address/#{address}/transactions?actions=send"), {address: address, actions: "send"})) do |result|  
+        result["status"].to_s.should eq("success")
           transactions = Array(Transaction).from_json(result["result"].to_json)
           transactions.map { |txn| txn.action }.uniq.should eq(["send"])
         end
@@ -362,7 +375,7 @@ describe RESTController do
       with_factory do |block_factory, transaction_factory|
         address = transaction_factory.sender_wallet.address
         block_factory.add_slow_blocks(200)
-        exec_rest_api(block_factory.rest.__v1_address_transactions(context("/api/v1/address/#{address}/transactions?page_size=50&page=2"), {address: address, page_size: 50, page: 1})) do |result|
+        exec_rest_api(block_factory.rest.__v1_address_transactions(context("/api/v1/address/#{address}/transactions?per_page=50&page=2"), {address: address, page_size: 50, page: 1})) do |result|
           result["status"].to_s.should eq("success")
           transactions = Array(Transaction).from_json(result["result"].to_json)
           transactions.size.should eq(50)
@@ -469,7 +482,7 @@ describe RESTController do
       with_factory do |block_factory, transaction_factory|
         domain = "sushi.sc"
         block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform(domain, 0_i64)]).add_slow_blocks(200)
-        exec_rest_api(block_factory.rest.__v1_domain_transactions(context("/api/v1/domain/#{domain}/transactions?page_size=50&page=2"), {domain: domain, page_size: 50, page: 1})) do |result|
+        exec_rest_api(block_factory.rest.__v1_domain_transactions(context("/api/v1/domain/#{domain}/transactions?per_page=50&page=2"), {domain: domain, page_size: 50, page: 1})) do |result|
           result["status"].to_s.should eq("success")
           transactions = Array(Transaction).from_json(result["result"].to_json)
           transactions.size.should eq(50)
@@ -615,7 +628,6 @@ describe RESTController do
       end
     end
   end
-
 end
 
 struct DomainResult

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -497,6 +497,7 @@ describe RESTController do
         domain = "sushi.sc"
         block_factory.add_slow_block([transaction_factory.make_buy_domain_from_platform(domain, 0_i64)]).add_slow_blocks(2).add_slow_block([transaction_factory.make_sell_domain(domain, 1_i64)]).add_slow_blocks(3)
         exec_rest_api(block_factory.rest.__v1_scars_sales(context("/api/v1/scars/sales"), no_params)) do |result|
+          pp result
           result["status"].to_s.should eq("success")
           result = Array(DomainResult).from_json(result["result"].to_json).first
           result.domain_name.should eq(domain)

--- a/spec/units/node/rest_controller.cr
+++ b/spec/units/node/rest_controller.cr
@@ -20,25 +20,26 @@ include Sushi::Core::Keys
 
 describe RESTController do
   describe "__v1_blockchain" do
-    it "should return the full blockchain when full chain fits into memory" do
+    it "should return the full blockchain with pagination defaults (page:0,per_page:20,direction:asc)" do
       with_factory do |block_factory, _|
-        block_factory.add_slow_blocks(2)
+        block_factory.add_slow_blocks(500)
         exec_rest_api(block_factory.rest.__v1_blockchain(context("/api/v1/blockchain"), no_params)) do |result|
           result["status"].to_s.should eq("success")
-          Array(SlowBlock).from_json(result["result"].to_json).size.should eq(3)
+          blocks = Array(SlowBlock).from_json(result["result"].to_json)
+          blocks.size.should eq(20)
+          blocks.first.index.should eq(0)
         end
       end
     end
-    it "should return the full blockchain when full chain is bigger than memory" do
-      with_factory do |block_factory, _|
-        blocks_to_add = block_factory.blocks_to_hold + 8
-        block_factory.add_slow_blocks(blocks_to_add)
-        exec_rest_api(block_factory.rest.__v1_blockchain(context("/api/v1/blockchain"), no_params)) do |result|
-          result["status"].to_s.should eq("success")
-          Array(SlowBlock).from_json(result["result"].to_json).size.should eq(blocks_to_add + 1)
-        end
-      end
-    end
+    # it "should return the full blockchain with pagination options" do
+    #   with_factory do |block_factory, _|
+    #     block_factory.add_slow_blocks(500)
+    #     exec_rest_api(block_factory.rest.__v1_blockchain(context("/api/v1/blockchain"), no_params)) do |result|
+    #       result["status"].to_s.should eq("success")
+    #       Array(SlowBlock).from_json(result["result"].to_json).size.should eq(blocks_to_add + 1)
+    #     end
+    #   end
+    # end
   end
 
   describe "__v1_blockchain_header" do
@@ -73,7 +74,7 @@ describe RESTController do
         end
       end
     end
-    it "should return the full blockchain size when chain is bigger than memory", focus: true do
+    it "should return the full blockchain size when chain is bigger than memory" do
       with_factory do |block_factory, _|
         blocks_to_add = block_factory.blocks_to_hold + 8
         block_factory.add_slow_blocks(blocks_to_add)

--- a/spec/utils/chain_generator.cr
+++ b/spec/utils/chain_generator.cr
@@ -46,7 +46,6 @@ module ::Units::Utils::ChainGenerator
       @node_wallet = Wallet.from_json(Wallet.create(true).to_json)
       @miner_wallet = Wallet.from_json(Wallet.create(true).to_json)
       @database = memory_kind == MemoryKind::SINGLE ? Sushi::Core::Database.in_memory : Sushi::Core::Database.in_shared_memory
-      @database = Sushi::Core::Database.new("./test.sqlite3")
       @node = Sushi::Core::Node.new(true, true, "bind_host", 8008_i32, nil, nil, nil, nil, nil, @node_wallet, @database, developer_fund, nil, 512, 512, false)
       @blockchain = @node.blockchain
       # the node setup is run in a spawn so we have to wait until it's finished before running any tests

--- a/spec/utils/chain_generator.cr
+++ b/spec/utils/chain_generator.cr
@@ -50,7 +50,7 @@ module ::Units::Utils::ChainGenerator
       @blockchain = @node.blockchain
       # the node setup is run in a spawn so we have to wait until it's finished before running any tests
       while @node.@phase != Sushi::Core::Node::SetupPhase::DONE
-        sleep 0.1
+        sleep 0.000001
       end
       @miner = {context: {address: miner_wallet.address, nonces: [] of UInt64}, socket: MockWebSocket.new, mid: "535061bddb0549f691c8b9c012a55ee2"}
       @transaction_factory = TransactionFactory.new(@node_wallet)

--- a/spec/utils/chain_generator.cr
+++ b/spec/utils/chain_generator.cr
@@ -46,6 +46,7 @@ module ::Units::Utils::ChainGenerator
       @node_wallet = Wallet.from_json(Wallet.create(true).to_json)
       @miner_wallet = Wallet.from_json(Wallet.create(true).to_json)
       @database = memory_kind == MemoryKind::SINGLE ? Sushi::Core::Database.in_memory : Sushi::Core::Database.in_shared_memory
+      @database = Sushi::Core::Database.new("./test.sqlite3")
       @node = Sushi::Core::Node.new(true, true, "bind_host", 8008_i32, nil, nil, nil, nil, nil, @node_wallet, @database, developer_fund, nil, 512, 512, false)
       @blockchain = @node.blockchain
       # the node setup is run in a spawn so we have to wait until it's finished before running any tests

--- a/src/cli/sushi/scars.cr
+++ b/src/cli/sushi/scars.cr
@@ -128,7 +128,7 @@ module ::Sushi::Interface::Sushi
 
       raise "the domain #{domain} is not resolved" unless resolved["resolved"].as_bool
 
-      if resolved["domain"]["status"] == Core::DApps::BuildIn::Scars::Status::FOR_SALE
+      if resolved["domain"]["status"] == Core::DApps::BuildIn::Status::FOR_SALE
         raise "the domain #{domain} is already for sale"
       end
 
@@ -165,7 +165,7 @@ module ::Sushi::Interface::Sushi
 
       raise "the domain #{domain} is not resolved" unless resolved["resolved"].as_bool
 
-      unless resolved["domain"]["status"] == Core::DApps::BuildIn::Scars::Status::FOR_SALE
+      unless resolved["domain"]["status"] == Core::DApps::BuildIn::Status::FOR_SALE
         raise "the domain #{domain} is not for sale"
       end
 
@@ -228,11 +228,11 @@ module ::Sushi::Interface::Sushi
         puts_success "resolved : #{resolved["resolved"]}"
 
         status = case resolved["domain"]["status"].as_i
-                 when Core::DApps::BuildIn::Scars::Status::ACQUIRED
+                 when Core::DApps::BuildIn::Status::ACQUIRED
                    "acquired"
-                 when Core::DApps::BuildIn::Scars::Status::FOR_SALE
+                 when Core::DApps::BuildIn::Status::FOR_SALE
                    "for sale"
-                 when Core::DApps::BuildIn::Scars::Status::NOT_FOUND
+                 when Core::DApps::BuildIn::Status::NOT_FOUND
                    "not found"
                  end
 

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -505,12 +505,6 @@ module ::Sushi::Core
       )
     end
 
-    def headers
-      # TODO - we don't want to load the entire db here - instead use a combination of in memory chain + database query
-      chain = @database.get_blocks(0_i64)
-      chain.map { |block| block.to_header }
-    end
-
     def transactions_for_address(address : String, page : Int32 = 0, page_size : Int32 = 20, actions : Array(String) = [] of String) : Array(Transaction)
       # TODO - we don't want to load the entire db here - instead use a combination of in memory chain + database query
       # TODO: Change this database request to something more sophisticated that filters out blocks that don't have txns with the address

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -254,11 +254,8 @@ module ::Sushi::Core
       debug "sending #{block.kind} block to DB with timestamp of #{block.timestamp}"
       @database.push_block(block)
       @chain.sort_by! { |blk| blk.index }
-      trim_chain_in_memory
-
-      debug "in blockchain._push_block, before dapps_record"
       dapps_record
-      debug "after dapps record, before clean transactions"
+      trim_chain_in_memory
     end
 
     def replace_chain(_slow_subchain : Chain?, _fast_subchain : Chain?) : Bool
@@ -385,6 +382,7 @@ module ::Sushi::Core
             debug "gonna delete at index #{i}"
             @chain.delete_at(i) if @chain[i].index >= index
           }
+          dapps_clear_record
         end
         break
       end
@@ -422,7 +420,7 @@ module ::Sushi::Core
             debug "gonna delete at index #{i}"
             @chain.delete_at(i) if @chain[i].index >= index
           }
-          # jjf @chain.each_index { |i| @chain.delete_at(i) if @chain[i].index >= index }
+         dapps_clear_record
         end
         break
       end

--- a/src/core/dapps/build_in/blockchain_info.cr
+++ b/src/core/dapps/build_in/blockchain_info.cr
@@ -111,7 +111,7 @@ module ::Sushi::Core::DApps::BuildIn
     end
 
     def transactions(json, context, params)
-      page, per_page, direction = 0, 10, 0
+      page, per_page, direction = 0, 50, 0
       context.response.print api_success(transactions_impl(json["index"]?, json["address"]?, page, per_page, direction))
       context
     end
@@ -131,7 +131,6 @@ module ::Sushi::Core::DApps::BuildIn
     end
 
     def transactions_address_impl(address : String, page : Int32, per_page : Int32, direction : Int32, actions : Array(String) = [] of String)
-      # blockchain.transactions_for_address(address, page, page_size, actions)
       database.get_paginated_transactions_for_address(address, page, per_page, Direction.new(direction).to_s, actions)
     end
 

--- a/src/core/dapps/build_in/blockchain_info.cr
+++ b/src/core/dapps/build_in/blockchain_info.cr
@@ -60,7 +60,7 @@ module ::Sushi::Core::DApps::BuildIn
     end
 
     def blockchain_size_impl
-      {size: blockchain.chain.size}
+      {size: database.total_blocks}
     end
 
     def blockchain(json, context, params)

--- a/src/core/dapps/build_in/blockchain_info.cr
+++ b/src/core/dapps/build_in/blockchain_info.cr
@@ -71,7 +71,7 @@ module ::Sushi::Core::DApps::BuildIn
 
     def blockchain_impl(header : Bool, page, per_page, direction)
       if header
-        blockchain.headers
+        database.get_paginated_blocks(page, per_page, Direction.new(direction).to_s).map(&.to_header)
       else
         database.get_paginated_blocks(page, per_page, Direction.new(direction).to_s)
       end
@@ -86,37 +86,28 @@ module ::Sushi::Core::DApps::BuildIn
 
     def block_impl(header : Bool, _index, _transaction_id)
       if index = _index
-        block_impl(header, index.as_i64)
+        block_index_impl(header, index.as_i64)
       elsif transaction_id = _transaction_id
-        block_impl(header, transaction_id.as_s)
+        block_transaction_impl(header, transaction_id.as_s)
       else
         raise "please specify block index or transaction id"
       end
     end
 
-    def block_impl(header : Bool, index : Int64)
-      if index > blockchain.latest_index
-        raise "invalid index #{index} (blockchain latest index is #{blockchain.latest_index})"
+    def block_index_impl(header : Bool, block_index : Int64)
+      if block = database.get_block(block_index)
+        header ? block.to_header : block
+      else
+        raise "failed to find a block for the index: #{block_index}"
       end
-
-      block = find_block(index)
-      header ? block.to_header : block
     end
 
-    def block_impl(header : Bool, transaction_id : String)
-      unless block_index = blockchain.indices.get(transaction_id)
+    def block_transaction_impl(header : Bool, transaction_id : String)
+      if block = database.get_block_for_transaction(transaction_id)
+        header ? block.to_header : block
+      else
         raise "failed to find a block for the transaction #{transaction_id}"
       end
-
-      block = find_block(block_index)
-      header ? block.to_header : block
-    end
-
-    private def find_block(block_index)
-      unless block = blockchain.chain.find{|blk| blk.index == block_index}
-        raise "failed to find a block in the chain with block index: #{block_index}"
-      end
-      block
     end
 
     def transactions(json, context, params)
@@ -129,7 +120,7 @@ module ::Sushi::Core::DApps::BuildIn
       if index = _index
         transactions_index_impl(index.as_i64, page, per_page, direction)
       elsif address = _address
-        transactions_address_impl(address.as_s)
+        transactions_address_impl(address.as_s, page, per_page, direction)
       else
         raise "please specify a block index or an address"
       end
@@ -139,13 +130,15 @@ module ::Sushi::Core::DApps::BuildIn
       database.get_paginated_transactions(block_index, page, per_page, Direction.new(direction).to_s)
     end
 
-    def transactions_address_impl(address : String, page : Int32 = 0, page_size : Int32 = 20, actions : Array(String) = [] of String)
-      blockchain.transactions_for_address(address, page, page_size, actions)
+    def transactions_address_impl(address : String, page : Int32, per_page : Int32, direction : Int32, actions : Array(String) = [] of String)
+      # blockchain.transactions_for_address(address, page, page_size, actions)
+      database.get_paginated_transactions_for_address(address, page, per_page, Direction.new(direction).to_s, actions)
     end
 
     def on_message(action : String, from_address : String, content : String, from = nil)
       false
     end
   end
+
   include NodeComponents::APIParams
 end

--- a/src/core/dapps/build_in/indices.cr
+++ b/src/core/dapps/build_in/indices.cr
@@ -45,6 +45,9 @@ module ::Sushi::Core::DApps::BuildIn
       true
     end
 
+    # TODO - this could be a view that has all the transactions per block
+    # can keep x amount in mem and when calling the impl check in-mem then go to db if not in mem
+    # record just refreshes the in-mem from the view
     def record(chain : Blockchain::Chain)
       the_chain = @blockchain.database.get_blocks_not_in_list(@indices.flat_map(&.values).uniq)
       the_chain.each do |block|
@@ -56,11 +59,11 @@ module ::Sushi::Core::DApps::BuildIn
       end
     end
 
-    def unrecord(block_id : Int64)
-      @indices.reverse.each do |h|
-        @indices.delete(h) if h.has_value?(block_id)
-      end
-    end
+    # def unrecord(block_id : Int64)
+    #   @indices.reverse.each do |h|
+    #     @indices.delete(h) if h.has_value?(block_id)
+    #   end
+    # end
 
     def clear
       @indices.clear

--- a/src/core/dapps/build_in/indices.cr
+++ b/src/core/dapps/build_in/indices.cr
@@ -12,17 +12,12 @@
 
 module ::Sushi::Core::DApps::BuildIn
   class Indices < DApp
-    @indices : Array(Hash(String, Int64)) = Array(Hash(String, Int64)).new
 
     def setup
     end
 
     def get(transaction_id : String) : Int64?
-      @indices.reverse.each do |indices|
-        return indices[transaction_id] if indices[transaction_id]?
-      end
-
-      nil
+      database.get_block_index_for_transaction(transaction_id)
     end
 
     def transaction_actions : Array(String)
@@ -35,7 +30,7 @@ module ::Sushi::Core::DApps::BuildIn
 
     def valid_transaction?(transaction : Transaction, prev_transactions : Array(Transaction)) : Bool
       if index = get(transaction.id)
-        raise "the transaction #{transaction.id} is already included in #{index}"
+        raise "the transaction #{transaction.id} is already included in block: #{index}"
       end
 
       if prev_transactions.count { |t| t.id == transaction.id } > 0
@@ -45,28 +40,10 @@ module ::Sushi::Core::DApps::BuildIn
       true
     end
 
-    # TODO - this could be a view that has all the transactions per block
-    # can keep x amount in mem and when calling the impl check in-mem then go to db if not in mem
-    # record just refreshes the in-mem from the view
     def record(chain : Blockchain::Chain)
-      the_chain = @blockchain.database.get_blocks_not_in_list(@indices.flat_map(&.values).uniq)
-      the_chain.each do |block|
-        @indices.push(Hash(String, Int64).new)
-
-        block.transactions.each do |transaction|
-          @indices[-1][transaction.id] = block.index
-        end
-      end
     end
 
-    # def unrecord(block_id : Int64)
-    #   @indices.reverse.each do |h|
-    #     @indices.delete(h) if h.has_value?(block_id)
-    #   end
-    # end
-
     def clear
-      @indices.clear
     end
 
     def define_rpc?(call, json, context, params) : HTTP::Server::Context?
@@ -89,7 +66,7 @@ module ::Sushi::Core::DApps::BuildIn
 
     def transaction_impl(transaction_id : String)
       if block_index = get(transaction_id)
-        if block = blockchain.chain.find { |blk| blk.index == block_index }
+        if block = database.get_block(block_index)
           if transaction = block.find_transaction(transaction_id)
             return {
               status:      "accepted",
@@ -132,10 +109,11 @@ module ::Sushi::Core::DApps::BuildIn
         raise "failed to find a block for the transaction #{transaction_id}"
       end
 
-      index = @indices.flat_map(&.values).uniq.count { |i| i > block_index }
+      highest_index = database.highest_index_of_kind(BlockKind::SLOW)
+      confirmations = (highest_index - block_index) / 2
 
       {
-        confirmations: index,
+        confirmations: confirmations.to_i,
       }
     end
 

--- a/src/core/dapps/build_in/rejects.cr
+++ b/src/core/dapps/build_in/rejects.cr
@@ -41,7 +41,7 @@ module ::Sushi::Core::DApps::BuildIn
     end
 
     # TODO - Store rejects in the db and only keep latest 10,000
-    # record should load the 10k into mem and trim the db  
+    # record should load the 10k into mem and trim the db
     def record(chain : Blockchain::Chain)
     end
 

--- a/src/core/dapps/build_in/rejects.cr
+++ b/src/core/dapps/build_in/rejects.cr
@@ -29,15 +29,19 @@ module ::Sushi::Core::DApps::BuildIn
       true
     end
 
+
     def record_reject(transaction_id : String, e : Exception)
       error_message = e.message ? e.message.not_nil! : "unknown"
       record_reject(transaction_id, error_message)
     end
 
+    # TODO - this should be recorded in the db
     def record_reject(transaction_id : String, error_message : String)
       @rejects[transaction_id] ||= error_message
     end
 
+    # TODO - Store rejects in the db and only keep latest 10,000
+    # record should load the 10k into mem and trim the db  
     def record(chain : Blockchain::Chain)
     end
 

--- a/src/core/dapps/build_in/rejects.cr
+++ b/src/core/dapps/build_in/rejects.cr
@@ -29,7 +29,6 @@ module ::Sushi::Core::DApps::BuildIn
       true
     end
 
-
     def record_reject(transaction_id : String, e : Exception)
       error_message = e.message ? e.message.not_nil! : "unknown"
       record_reject(transaction_id, error_message)

--- a/src/core/dapps/build_in/scars.cr
+++ b/src/core/dapps/build_in/scars.cr
@@ -171,7 +171,7 @@ RULE
     end
 
     private def lookup_for(address : String) : Array(Domain)
-      database.get_domain_map_for_address(address).map { |name, domain| domain }
+      database.get_domain_map_for_address(address).map { |_, domain| domain }
     end
 
     private def create_domain_map_for_transactions(transactions : Array(Transaction)) : DomainMap

--- a/src/core/dapps/build_in/scars.cr
+++ b/src/core/dapps/build_in/scars.cr
@@ -28,38 +28,19 @@ module ::Sushi::Core::DApps::BuildIn
   alias DomainMap = Hash(String, Domain)
 
   class Scars < DApp
-    
-    @domains_internal : Array(DomainMap) = Array(DomainMap).new
 
     def setup
     end
 
-    def sales
-      domain_all = DomainMap.new
 
-      @domains_internal.reverse.each do |domain_map|
-        domain_map.each do |domain_name, domain|
-          domain_all[domain_name] ||= domain
-        end
-      end
-
-      domain_all
-        .select { |_, domain| domain[:status] == Status::FOR_SALE }
-        .map { |_, domain| scale_decimal(domain) }
-    end
-
-    def resolve(domain_name : String, confirmation : Int32) : Domain?
+    def resolve(domain_name : String, confirmation_depth : Int32) : Domain?
       # return nil if @domains_internal.size < confirmation
-      resolve_for(domain_name, @domains_internal.reverse[(confirmation - 1)..-1])
+      resolve_for(domain_name, confirmation_depth)
     end
 
     def resolve_pending(domain_name : String, transactions : Array(Transaction)) : Domain?
       domain_map = create_domain_map_for_transactions(transactions)
-
-      tmp_domains_internal = @domains_internal.dup
-      tmp_domains_internal.push(domain_map)
-
-      resolve_for(domain_name, tmp_domains_internal.reverse)
+      domain_map[domain_name]?
     end
 
     def lookup(address : String) : Array(Domain)?
@@ -183,39 +164,32 @@ RULE
     end
 
     def record(chain)
-      the_chain = @blockchain.database.get_blocks(@domains_internal.size.to_i64)
-      the_chain.each do |block|
-        domain_map = create_domain_map_for_transactions(block.transactions)
-        @domains_internal.push(domain_map)
-      end
+      # the_chain = @blockchain.database.get_blocks(@domains_internal.size.to_i64)
+      # the_chain.each do |block|
+      #   domain_map = create_domain_map_for_transactions(block.transactions)
+      #   @domains_internal.push(domain_map)
+      # end
     end
 
     def clear
-      @domains_internal.clear
+      # @domains_internal.clear
     end
-
-    # private def resolve_for(domain_name : String, domains : Array(DomainMap)) : Domain?
-    #   domains.each do |domains_internal|
-    #     return domains_internal[domain_name] if domains_internal[domain_name]?
-    #   end
-
-    #   nil
-    # end
-
-    private def resolve_for(domain_name : String, domains : Array(DomainMap)) : Domain?
+ 
+    private def resolve_for(domain_name : String, confirmation_depth : Int32) : Domain?
       database.get_domain_map_for(domain_name)[domain_name]?
     end
 
     private def lookup_for(address : String) : Array(Domain)?
-      matched_domains = Array(Domain).new
+      # matched_domains = Array(Domain).new
 
-      @domains_internal.reverse.each do |domain_map|
-        domain_map.each do |_, domain|
-          matched_domains << domain if domain[:address] == address
-        end
-      end
+      # @domains_internal.reverse.each do |domain_map|
+      #   domain_map.each do |_, domain|
+      #     matched_domains << domain if domain[:address] == address
+      #   end
+      # end
 
-      matched_domains
+      # matched_domains
+      [] of Domain
     end
 
     private def create_domain_map_for_transactions(transactions : Array(Transaction)) : DomainMap
@@ -309,7 +283,7 @@ RULE
     end
 
     def scars_for_sale_impl
-      sales
+      database.get_domains_for_sale
     end
 
     def scars_lookup(json, context, params)
@@ -326,9 +300,9 @@ RULE
       domains.each do |domain|
         domain_results << DomainResult.new(
           domain_name: domain[:domain_name],
-          address:     domain[:address],
-          status:      domain[:status],
-          price:       scale_decimal(domain[:price]))
+          address: domain[:address],
+          status: domain[:status],
+          price: scale_decimal(domain[:price]))
       end
       {address: address, domains: domain_results}
     end

--- a/src/core/dapps/build_in/scars.cr
+++ b/src/core/dapps/build_in/scars.cr
@@ -17,17 +17,18 @@ module ::Sushi::Core::DApps::BuildIn
   # valid suffixes
   SUFFIX = %w(sc)
 
+  enum Status
+    ACQUIRED
+    FOR_SALE
+    NOT_FOUND = -1
+  end
+
+  alias Domain = NamedTuple(domain_name: String, address: String, status: Status, price: Int64)
+  alias DomainResult = NamedTuple(domain_name: String, address: String, status: Status, price: String)
+  alias DomainMap = Hash(String, Domain)
+
   class Scars < DApp
-    module Status
-      ACQUIRED  =  0
-      FOR_SALE  =  1
-      NOT_FOUND = -1
-    end
-
-    alias Domain = NamedTuple(domain_name: String, address: String, status: Int32, price: Int64)
-    alias DomainResult = NamedTuple(domain_name: String, address: String, status: Int32, price: String)
-    alias DomainMap = Hash(String, Domain)
-
+    
     @domains_internal : Array(DomainMap) = Array(DomainMap).new
 
     def setup
@@ -48,7 +49,7 @@ module ::Sushi::Core::DApps::BuildIn
     end
 
     def resolve(domain_name : String, confirmation : Int32) : Domain?
-      return nil if @domains_internal.size < confirmation
+      # return nil if @domains_internal.size < confirmation
       resolve_for(domain_name, @domains_internal.reverse[(confirmation - 1)..-1])
     end
 
@@ -193,12 +194,16 @@ RULE
       @domains_internal.clear
     end
 
-    private def resolve_for(domain_name : String, domains : Array(DomainMap)) : Domain?
-      domains.each do |domains_internal|
-        return domains_internal[domain_name] if domains_internal[domain_name]?
-      end
+    # private def resolve_for(domain_name : String, domains : Array(DomainMap)) : Domain?
+    #   domains.each do |domains_internal|
+    #     return domains_internal[domain_name] if domains_internal[domain_name]?
+    #   end
 
-      nil
+    #   nil
+    # end
+
+    private def resolve_for(domain_name : String, domains : Array(DomainMap)) : Domain?
+      database.get_domain_map_for(domain_name)[domain_name]?
     end
 
     private def lookup_for(address : String) : Array(Domain)?

--- a/src/core/dapps/build_in/scars.cr
+++ b/src/core/dapps/build_in/scars.cr
@@ -32,13 +32,12 @@ module ::Sushi::Core::DApps::BuildIn
     end
 
     def resolve(domain_name : String, confirmation_depth : Int32) : Domain?
-      # return nil if @domains_internal.size < confirmation
       resolve_for(domain_name, confirmation_depth)
     end
 
     def resolve_pending(domain_name : String, transactions : Array(Transaction)) : Domain?
       domain_map = create_domain_map_for_transactions(transactions)
-      domain_map[domain_name]?
+      domain_map[domain_name]? || resolve_for(domain_name, 1)
     end
 
     def lookup(address : String) : Array(Domain)?

--- a/src/core/dapps/build_in/scars.cr
+++ b/src/core/dapps/build_in/scars.cr
@@ -28,10 +28,8 @@ module ::Sushi::Core::DApps::BuildIn
   alias DomainMap = Hash(String, Domain)
 
   class Scars < DApp
-
     def setup
     end
-
 
     def resolve(domain_name : String, confirmation_depth : Int32) : Domain?
       # return nil if @domains_internal.size < confirmation
@@ -164,32 +162,17 @@ RULE
     end
 
     def record(chain)
-      # the_chain = @blockchain.database.get_blocks(@domains_internal.size.to_i64)
-      # the_chain.each do |block|
-      #   domain_map = create_domain_map_for_transactions(block.transactions)
-      #   @domains_internal.push(domain_map)
-      # end
     end
 
     def clear
-      # @domains_internal.clear
     end
- 
+
     private def resolve_for(domain_name : String, confirmation_depth : Int32) : Domain?
       database.get_domain_map_for(domain_name)[domain_name]?
     end
 
-    private def lookup_for(address : String) : Array(Domain)?
-      # matched_domains = Array(Domain).new
-
-      # @domains_internal.reverse.each do |domain_map|
-      #   domain_map.each do |_, domain|
-      #     matched_domains << domain if domain[:address] == address
-      #   end
-      # end
-
-      # matched_domains
-      [] of Domain
+    private def lookup_for(address : String) : Array(Domain)
+      database.get_domain_map_for_address(address).map { |name, domain| domain }
     end
 
     private def create_domain_map_for_transactions(transactions : Array(Transaction)) : DomainMap
@@ -283,7 +266,7 @@ RULE
     end
 
     def scars_for_sale_impl
-      database.get_domains_for_sale
+      database.get_domains_for_sale.map { |d| scale_decimal(d) }
     end
 
     def scars_lookup(json, context, params)

--- a/src/core/dapps/build_in/token.cr
+++ b/src/core/dapps/build_in/token.cr
@@ -77,6 +77,8 @@ RULE
       Token.valid_token_name?(token)
     end
 
+    # TODO - this could be a view that lists all the tokens 
+    # always get it from the view and paginate
     def record(chain : Blockchain::Chain)
       the_chain = @blockchain.database.get_blocks_not_in_list(@recorded_indices)
       the_chain.each do |block|

--- a/src/core/dapps/build_in/token.cr
+++ b/src/core/dapps/build_in/token.cr
@@ -77,7 +77,7 @@ RULE
       Token.valid_token_name?(token)
     end
 
-    # TODO - this could be a view that lists all the tokens 
+    # TODO - this could be a view that lists all the tokens
     # always get it from the view and paginate
     def record(chain : Blockchain::Chain)
       the_chain = @blockchain.database.get_blocks_not_in_list(@recorded_indices)

--- a/src/core/dapps/build_in/token.cr
+++ b/src/core/dapps/build_in/token.cr
@@ -50,7 +50,7 @@ module ::Sushi::Core::DApps::BuildIn
 
       raise "invalid token name: #{token}" unless valid_token_name?(token)
 
-      raise "the token #{token} is already created" if @tokens.includes?(token)
+      raise "the token #{token} is already created" if database.token_exists?(token)
 
       prev_transactions.each do |prev_transaction|
         raise "the token #{token} is already created" if prev_transaction.token == token
@@ -77,8 +77,6 @@ RULE
       Token.valid_token_name?(token)
     end
 
-    # TODO - this could be a view that lists all the tokens
-    # always get it from the view and paginate
     def record(chain : Blockchain::Chain)
       the_chain = @blockchain.database.get_blocks_not_in_list(@recorded_indices)
       the_chain.each do |block|
@@ -103,8 +101,7 @@ RULE
     def clear
       @tokens.clear
       @tokens << "SUSHI"
-
-      @recorded_indices = [] of Int64
+      @recorded_indices.clear
     end
 
     def define_rpc?(call, json, context, params) : HTTP::Server::Context?
@@ -117,12 +114,13 @@ RULE
     end
 
     def list(json, context, params)
-      context.response.print api_success(tokens_list_impl)
+      page, per_page, direction = 0, 50, 0
+      context.response.print api_success(tokens_list_impl(page, per_page, direction))
       context
     end
 
-    def tokens_list_impl
-      @tokens
+    def tokens_list_impl(page, per_page, direction)
+      (["SUSHI"] + database.get_paginated_tokens(page, per_page, Direction.new(direction).to_s)).to_set
     end
 
     def self.fee(action : String) : Int64

--- a/src/core/dapps/dapp.cr
+++ b/src/core/dapps/dapp.cr
@@ -62,6 +62,10 @@ module ::Sushi::Core::DApps
       @blockchain.node
     end
 
+    private def database : Database
+      @blockchain.database
+    end
+
     include Logger
     include Protocol
     include Common::Denomination

--- a/src/core/database/blocks.cr
+++ b/src/core/database/blocks.cr
@@ -1,0 +1,165 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+require "../blockchain/*"
+require "../blockchain/block/*"
+
+module ::Sushi::Core::Data::Blocks
+  # ------- Definition -------
+  def block_table_create_string : String
+    "idx integer primary key, nonce text, prev_hash text, timestamp integer, difficulty integer, address text, kind text, public_key text, sign_r text, sign_s text, hash text"
+  end
+
+  def block_insert_fields_string : String
+    "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
+  end
+
+  # ------- Insert -------
+  def block_insert_values_array(block : SlowBlock | FastBlock) : Array(DB::Any)
+    ary = [] of DB::Any
+    case block
+    when SlowBlock
+      ary << block.index << block.nonce.to_s << block.prev_hash << block.timestamp << block.difficulty << block.address << block.kind.to_s << "" << "" << "" << ""
+    when FastBlock
+      ary << block.index << "" << block.prev_hash << block.timestamp << 0 << block.address << block.kind.to_s << block.public_key << block.sign_r << block.sign_s << block.hash
+    end
+    ary
+  end
+
+  def push_block(block : SlowBlock | FastBlock)
+    verbose "database.push_block with block index #{block.index} of kind: #{block.kind}"
+    @db.exec "BEGIN TRANSACTION"
+    block.transactions.each_with_index do |t, ti|
+      verbose "writing transaction #{ti} to database with short ID of #{t.short_id}" if ti < 4
+      t.senders.each_index do |i|
+        @db.exec "insert into senders values (#{sender_insert_fields_string})", args: sender_insert_values_array(block, t, i)
+      end
+      t.recipients.each_index do |i|
+        @db.exec "insert into recipients values (#{recipient_insert_fields_string})", args: recipient_insert_values_array(block, t, i)
+      end
+      @db.exec "insert into transactions values (#{transaction_insert_fields_string})", args: transaction_insert_values_array(t, ti, block.index)
+    end
+    verbose "inserting block with #{block.transactions.size} transactions into database with index: #{block.index}"
+    @db.exec "insert into blocks values (#{block_insert_fields_string})", args: block_insert_values_array(block)
+    @db.exec "END TRANSACTION"
+  end
+
+  # ------- Query -------
+  def get_blocks_via_query(the_query, *args) : Blockchain::Chain
+    blocks : Blockchain::Chain = [] of SlowBlock | FastBlock
+    @db.query(the_query, args: args.to_a) do |rows|
+      rows.each do
+        idx = rows.read(Int64)
+        nonce_string = rows.read(String)
+        nonce = nonce_string.size > 0 ? nonce_string.to_u64 : 0_u64
+        prev_hash = rows.read(String)
+        timestamp = rows.read(Int64)
+        diffculty = rows.read(Int32)
+        address = rows.read(String)
+        kind_string = rows.read(String)
+        public_key = rows.read(String)
+        sign_r = rows.read(String)
+        sign_s = rows.read(String)
+        hash = rows.read(String)
+        verbose "read block idx: #{idx}"
+        verbose "read nonce string: #{nonce_string}"
+        verbose "read nonce: #{nonce}"
+        verbose "read prev_hash: #{prev_hash}"
+        verbose "read timestamp: #{timestamp}"
+        verbose "read address: #{address}"
+        verbose "read block kind: #{kind_string}"
+        if kind_string == "SLOW"
+          verbose "read diffculty: #{diffculty}"
+          blocks << SlowBlock.new(idx, [] of Transaction, nonce, prev_hash, timestamp, diffculty, address)
+        else
+          verbose "read public_key: #{public_key}"
+          verbose "read sign_r: #{sign_r}"
+          verbose "read sign_s: #{sign_s}"
+          verbose "read hash: #{hash}"
+          blocks << FastBlock.new(idx, [] of Transaction, prev_hash, timestamp, address, public_key, sign_r, sign_s, hash)
+        end
+      end
+    end
+
+    blocks.each do |block|
+      case block
+      when SlowBlock
+        block.set_transactions(get_all_transactions(block.index))
+      when FastBlock
+        block.set_transactions(get_all_transactions(block.index))
+      end
+    end
+
+    blocks
+  end
+
+  def get_block(index : Int64) : Block?
+    verbose "Reading block from the database for block #{index}"
+    block : Block? = nil
+    blocks = get_blocks_via_query("select * from blocks where idx = ?", index)
+    block = blocks[0] if blocks.size > 0
+    block
+  end
+
+  def get_blocks(index : Int64) : Blockchain::Chain
+    verbose "Reading blocks from the database starting at block #{index}"
+    get_blocks_via_query("select * from blocks where idx >= ?", index)
+  end
+
+  def get_slow_blocks(index : Int64) : Blockchain::Chain
+    verbose "Reading blocks from the database starting at block #{index}"
+    if index == 0
+      get_blocks_via_query("select * from blocks where idx >= ? and kind = 'SLOW'", index)
+    else
+      get_blocks_via_query("select * from blocks where idx > ? and kind = 'SLOW'", index)
+    end
+  end
+
+  def get_fast_blocks(index : Int64) : Blockchain::Chain
+    verbose "Reading blocks from the database starting at block #{index}"
+    blocks = get_blocks_via_query("select * from blocks where idx > ? and kind = 'FAST'", index)
+    blocks
+  end
+
+  def get_blocks_not_in_list(the_list : Array(Int64))
+    verbose "get_blocks_not_in_list called, list length: #{the_list.size}"
+    index_list = the_list.map(&.to_s).join(",")
+    get_blocks_via_query("select * from blocks where idx not in (#{index_list})")
+  end
+
+  def total_blocks : Int32
+    @db.query_one("select count(*) from blocks", as: Int32)
+  end
+
+  # ------- Delete -------
+  def delete_block(from : Int64)
+    @db.exec "delete from blocks where idx = ?", from
+    @db.exec "delete from transactions where block_id = ?", from
+    @db.exec "delete from senders where block_id = ?", from
+    @db.exec "delete from recipients where block_id = ?", from
+  end
+
+  def delete_blocks(from : Int64)
+    @db.exec "delete from blocks where idx >= ?", from
+    @db.exec "delete from transactions where block_id >= ?", from
+    @db.exec "delete from senders where block_id >= ?", from
+    @db.exec "delete from recipients where block_id >= ?", from
+  end
+
+  # ------- API -------
+  def get_paginated_blocks(page, per_page, direction) : Blockchain::Chain
+    get_blocks_via_query(
+      "select * from blocks " \
+      "where oid not in ( select oid from blocks " \
+      "order by idx #{direction} limit ? ) " \
+      "order by idx #{direction} limit ?", page, per_page)
+  end
+end

--- a/src/core/database/blocks.cr
+++ b/src/core/database/blocks.cr
@@ -109,6 +109,17 @@ module ::Sushi::Core::Data::Blocks
     block
   end
 
+  def get_block_for_transaction(transaction_id : String) : Block?
+    verbose "Reading block from the database for transaction #{transaction_id}"
+    block : Block? = nil
+    blocks = get_blocks_via_query(
+      "select * from blocks where idx in " \
+      "(select block_id from transactions where id = ?)",
+      transaction_id)
+    block = blocks[0] if blocks.size > 0
+    block
+  end
+
   def get_blocks(index : Int64) : Blockchain::Chain
     verbose "Reading blocks from the database starting at block #{index}"
     get_blocks_via_query("select * from blocks where idx >= ?", index)

--- a/src/core/database/database.cr
+++ b/src/core/database/database.cr
@@ -11,6 +11,7 @@
 # Removal or modification of this copyright notice is prohibited.
 require "../blockchain/*"
 require "../blockchain/block/*"
+require "../database/*"
 
 module ::Sushi::Core
   class Database
@@ -28,111 +29,6 @@ module ::Sushi::Core
       @db.exec "PRAGMA cache_size=10000"
     end
 
-    def block_table_create_string : String
-      "idx integer primary key, nonce text, prev_hash text, timestamp integer, difficulty integer, address text, kind text, public_key text, sign_r text, sign_s text, hash text"
-    end
-
-    def block_insert_fields_string : String
-     "?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
-    end
-
-    def block_insert_values_array(block : SlowBlock | FastBlock) : Array(DB::Any)
-      ary = [] of DB::Any
-      case block
-        when SlowBlock
-          ary << block.index << block.nonce.to_s << block.prev_hash << block.timestamp << block.difficulty << block.address << block.kind.to_s << "" << "" << "" << ""
-        when FastBlock
-          ary << block.index << "" << block.prev_hash << block.timestamp << 0 << block.address << block.kind.to_s << block.public_key << block.sign_r << block.sign_s << block.hash
-      end
-      ary
-    end
-
-    def transaction_table_create_string
-      "id text, idx integer, block_id integer, action text, message text, token text, prev_hash text, timestamp integer, scaled integer, kind text"
-    end
-
-    def transaction_primary_key_string
-      "id, idx, block_id"
-    end
-
-    def transaction_insert_fields_string
-      "?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
-    end
-
-    def transaction_insert_values_array(t : Transaction, transaction_idx : Int32, block_index : Int64) : Array(DB::Any)
-      ary = [] of DB::Any
-      ary << t.id << transaction_idx << block_index << t.action << t.message << t.token << t.prev_hash << t.timestamp << t.scaled << t.kind.to_s
-    end
-
-    def sender_table_create_string
-      "transaction_id text, block_id integer, idx integer, address text, public_key text, amount integer, fee integer, sign_r text, sign_s text"
-    end
-
-    def sender_primary_key_string
-      "transaction_id, block_id, idx"
-    end
-
-    def sender_insert_fields_string
-      "?, ?, ?, ?, ?, ?, ?, ?, ?"
-    end
-
-    def sender_insert_values_array(b : Block, t : Transaction, sender_index : Int32) : Array(DB::Any)
-      ary = [] of DB::Any
-      s = t.senders[sender_index]
-      ary << t.id << b.index << sender_index << s[:address] << s[:public_key] << s[:amount] << s[:fee] << s[:sign_r] << s[:sign_s]
-    end
-
-    def recipient_table_create_string
-      "transaction_id text, block_id integer, idx integer, address text, amount integer"
-    end
-
-    def recipient_primary_key_string
-      "transaction_id, block_id, idx"
-    end
-
-    def recipient_insert_fields_string
-      "?, ?, ?, ?, ?"
-    end
-
-    def recipient_insert_values_array(b : Block, t : Transaction, recipient_index : Int32) : Array(DB::Any)
-      ary = [] of DB::Any
-      r = t.recipients[recipient_index]
-      ary << t.id << b.index << recipient_index << r[:address] << r[:amount]
-    end
-
-    def push_block(block : SlowBlock | FastBlock)
-      verbose "database.push_block with block index #{block.index} of kind: #{block.kind}"
-      @db.exec "BEGIN TRANSACTION"
-      block.transactions.each_index do |ti|
-        t = block.transactions[ti]
-        verbose "writing transaction #{ti} to database with short ID of #{t.short_id}" if ti < 4
-        t.senders.each_index do |i|
-         @db.exec "insert into senders values (#{sender_insert_fields_string})", args: sender_insert_values_array(block, t, i)
-        end
-        t.recipients.each_index do |i|
-         @db.exec "insert into recipients values (#{recipient_insert_fields_string})", args: recipient_insert_values_array(block, t, i)
-        end
-       @db.exec "insert into transactions values (#{transaction_insert_fields_string})", args: transaction_insert_values_array(t, ti, block.index)
-      end
-      verbose "inserting block with #{block.transactions.size} transactions into database with index: #{block.index}"
-      @db.exec "insert into blocks values (#{block_insert_fields_string})", args: block_insert_values_array(block)
-      @db.exec "END TRANSACTION"
-    end
-
-    def delete_block(from : Int64)
-      @db.exec "delete from blocks where idx = ?", from
-      @db.exec "delete from transactions where block_id = ?", from
-      @db.exec "delete from senders where block_id = ?", from
-      @db.exec "delete from recipients where block_id = ?", from
-    end
-
-    def delete_blocks(from : Int64)
-      @db.exec "delete from blocks where idx >= ?", from
-      @db.exec "delete from transactions where block_id >= ?", from
-      @db.exec "delete from senders where block_id >= ?", from
-      @db.exec "delete from recipients where block_id >= ?", from
-    end
-
     def replace_block(block : SlowBlock | FastBlock)
       delete_block(block.index)
       push_block(block)
@@ -144,156 +40,6 @@ module ::Sushi::Core
       chain.each do |block|
         push_block(block)
       end
-    end
-
-    def get_senders(t : Transaction) : Transaction::Senders
-      senders = [] of Transaction::Sender
-      @db.query "select * from senders where transaction_id = ? order by idx", t.id do |rows|
-        rows.each do
-          rows.read(String?)
-          rows.read(Int64)
-          rows.read(Int32)
-          senders << {address: rows.read(String), public_key: rows.read(String), amount: rows.read(Int64), fee: rows.read(Int64),
-                      sign_r: rows.read(String), sign_s: rows.read(String) }
-        end
-      end
-      senders
-    end
-
-    def get_recipients(t : Transaction) : Transaction::Recipients
-      recipients = [] of Transaction::Recipient
-      @db.query "select * from recipients where transaction_id = ? order by idx", t.id do |rows|
-        rows.each do
-          rows.read(String)
-          rows.read(Int64)
-          rows.read(Int32)
-          recipients << {address: rows.read(String), amount: rows.read(Int64) }
-        end
-      end
-      recipients
-    end
-
-    def get_transactions(index : Int64)
-      transactions = [] of Transaction
-      verbose "Reading transactions from the database for block #{index}"
-      ti = 0
-      @db.query "select * from transactions where block_id = ? order by idx asc", index do |rows|
-        rows.each do
-          t_id = rows.read(String)
-          rows.read(Int32)
-          rows.read(Int64)
-          action = rows.read(String)
-          message = rows.read(String)
-          token = rows.read(String)
-          prev_hash = rows.read(String)
-          timestamp = rows.read(Int64)
-          scaled = rows.read(Int32)
-          kind_string = rows.read(String)
-          kind = kind_string == "SLOW" ? TransactionKind::SLOW : TransactionKind::FAST
-
-          t = Transaction.new(t_id, action, [] of Transaction::Sender, [] of Transaction::Recipient, message, token, prev_hash, timestamp, scaled, kind)
-          transactions << t
-          verbose "reading transaction #{ti} from database with short ID of #{t.short_id}" if ti < 4
-          ti += 1
-        end
-      end
-      transactions.each do |t|
-        t.set_senders(get_senders(t))
-        t.set_recipients(get_recipients(t))
-      end
-      transactions
-    end
-
-    def get_blocks_via_query(the_query : String) : Blockchain::Chain
-      blocks : Blockchain::Chain = [] of SlowBlock | FastBlock
-      @db.query the_query do |rows|
-        rows.each do
-          idx = rows.read(Int64)
-          nonce_string = rows.read(String)
-          nonce = nonce_string.size > 0 ? nonce_string.to_u64 : 0_u64
-          prev_hash = rows.read(String)
-          timestamp = rows.read(Int64)
-          diffculty = rows.read(Int32)
-          address = rows.read(String)
-          kind_string = rows.read(String)
-          public_key = rows.read(String)
-          sign_r = rows.read(String)
-          sign_s = rows.read(String)
-          hash = rows.read(String)
-          verbose "read block idx: #{idx}"
-          verbose "read nonce string: #{nonce_string}"
-          verbose "read nonce: #{nonce}"
-          verbose "read prev_hash: #{prev_hash}"
-          verbose "read timestamp: #{timestamp}"
-          verbose "read address: #{address}"
-          verbose "read block kind: #{kind_string}"
-          if kind_string == "SLOW"
-            verbose "read diffculty: #{diffculty}"
-            blocks << SlowBlock.new(idx, [] of Transaction, nonce, prev_hash, timestamp, diffculty, address)
-          else
-            verbose "read public_key: #{public_key}"
-            verbose "read sign_r: #{sign_r}"
-            verbose "read sign_s: #{sign_s}"
-            verbose "read hash: #{hash}"
-            blocks << FastBlock.new(idx, [] of Transaction, prev_hash, timestamp, address, public_key, sign_r, sign_s, hash)
-          end
-        end
-      end
-
-      blocks.each do |block|
-        case block
-          when SlowBlock
-            block.set_transactions(get_transactions(block.index))
-          when FastBlock
-            block.set_transactions(get_transactions(block.index))
-        end
-      end
-
-      blocks
-    end
-
-    def get_block(index : Int64) : Block?
-      verbose "Reading block from the database for block #{index}"
-      block : Block? = nil
-      blocks = get_blocks_via_query("select * from blocks where idx = #{index}")
-      block = blocks[0] if blocks.size > 0
-      block
-    end
-
-    def get_blocks(index : Int64) : Blockchain::Chain
-      verbose "Reading blocks from the database starting at block #{index}"
-      blocks = get_blocks_via_query("select * from blocks where idx >= #{index}")
-      blocks
-    end
-
-    def get_slow_blocks(index : Int64) : Blockchain::Chain
-      verbose "Reading blocks from the database starting at block #{index}"
-      if index == 0
-        get_blocks_via_query("select * from blocks where idx >= #{index} and kind = 'SLOW'")
-      else
-        get_blocks_via_query("select * from blocks where idx > #{index} and kind = 'SLOW'")
-      end
-    end
-
-    def get_fast_blocks(index : Int64) : Blockchain::Chain
-      verbose "Reading blocks from the database starting at block #{index}"
-      blocks = get_blocks_via_query("select * from blocks where idx > #{index} and kind = 'FAST'")
-      blocks
-    end
-
-    def get_blocks_not_in_list(the_list : Array(Int64))
-      verbose "get_blocks_not_in_list called, list length: #{the_list.size}"
-      the_index_list = ""
-      the_list.each_index do |i|
-        the_index_list += the_list[i].to_s
-        the_index_list += ", " if i < the_list.size - 1
-      end
-      blocks = get_blocks_via_query("select * from blocks where idx not in (#{the_index_list})")
-      blocks
-    end
-
-    def total_blocks : Int32
-      @db.query_one("select count(*) from blocks", as: Int32)
     end
 
     def highest_index_of_kind(kind : Block::BlockKind) : Int64
@@ -323,5 +69,9 @@ module ::Sushi::Core
     end
 
     include Logger
+    include Data::Blocks
+    include Data::Senders
+    include Data::Recipients
+    include Data::Transactions
   end
 end

--- a/src/core/database/database.cr
+++ b/src/core/database/database.cr
@@ -16,6 +16,8 @@ require "../database/*"
 module ::Sushi::Core
   class Database
     getter path : String
+    MEMORY = "%3Amemory%3A"
+    SHARED_MEMORY = "%3Amemory%3A%3Fcache%3Dshared"
 
     @db : DB::Database
 
@@ -27,6 +29,18 @@ module ::Sushi::Core
       @db.exec "create table if not exists senders (#{sender_table_create_string}, primary key (#{sender_primary_key_string}))"
       @db.exec "PRAGMA synchronous=OFF"
       @db.exec "PRAGMA cache_size=10000"
+    end
+
+    def self.in_memory
+      self.new(MEMORY)
+    end
+
+    def self.in_shared_memory
+      self.new(SHARED_MEMORY)
+    end
+
+    private def memory_or_disk(value : String) : String
+      value.starts_with?(MEMORY) ? value : File.expand_path(value)
     end
 
     def replace_block(block : SlowBlock | FastBlock)

--- a/src/core/database/database.cr
+++ b/src/core/database/database.cr
@@ -24,7 +24,7 @@ module ::Sushi::Core
       @db.exec "create table if not exists transactions (#{transaction_table_create_string}, primary key (#{transaction_primary_key_string}))"
       @db.exec "create table if not exists recipients (#{recipient_table_create_string}, primary key (#{recipient_primary_key_string}))"
       @db.exec "create table if not exists senders (#{sender_table_create_string}, primary key (#{sender_primary_key_string}))"
-      @db.exec "PRAGMA synchonous = OFF"
+      @db.exec "PRAGMA synchronous=OFF"
       @db.exec "PRAGMA cache_size=10000"
     end
 

--- a/src/core/database/recipients.cr
+++ b/src/core/database/recipients.cr
@@ -1,0 +1,52 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+require "../blockchain/*"
+require "../blockchain/block/*"
+
+module ::Sushi::Core::Data::Recipients
+  # ------- Definition -------
+  def recipient_table_create_string
+    "transaction_id text, block_id integer, idx integer, address text, amount integer"
+  end
+
+  def recipient_primary_key_string
+    "transaction_id, block_id, idx"
+  end
+
+  def recipient_insert_fields_string
+    "?, ?, ?, ?, ?"
+  end
+
+  # ------- Insert -------
+  def recipient_insert_values_array(b : Block, t : Transaction, recipient_index : Int32) : Array(DB::Any)
+    ary = [] of DB::Any
+    r = t.recipients[recipient_index]
+    ary << t.id << b.index << recipient_index << r[:address] << r[:amount]
+  end
+
+  # ------- Query -------
+  def get_recipients(t : Transaction) : Transaction::Recipients
+    recipients = [] of Transaction::Recipient
+    @db.query "select * from recipients where transaction_id = ? order by idx", t.id do |rows|
+      rows.each do
+        rows.read(String)
+        rows.read(Int64)
+        rows.read(Int32)
+        recipients << {
+          address: rows.read(String),
+          amount:  rows.read(Int64),
+        }
+      end
+    end
+    recipients
+  end
+end

--- a/src/core/database/senders.cr
+++ b/src/core/database/senders.cr
@@ -1,0 +1,56 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+require "../blockchain/*"
+require "../blockchain/block/*"
+
+module ::Sushi::Core::Data::Senders
+  # ------- Definition -------
+  def sender_table_create_string
+    "transaction_id text, block_id integer, idx integer, address text, public_key text, amount integer, fee integer, sign_r text, sign_s text"
+  end
+
+  def sender_primary_key_string
+    "transaction_id, block_id, idx"
+  end
+
+  def sender_insert_fields_string
+    "?, ?, ?, ?, ?, ?, ?, ?, ?"
+  end
+
+  # ------- Insert -------
+  def sender_insert_values_array(b : Block, t : Transaction, sender_index : Int32) : Array(DB::Any)
+    ary = [] of DB::Any
+    s = t.senders[sender_index]
+    ary << t.id << b.index << sender_index << s[:address] << s[:public_key] << s[:amount] << s[:fee] << s[:sign_r] << s[:sign_s]
+  end
+
+  # ------- Query -------
+  def get_senders(t : Transaction) : Transaction::Senders
+    senders = [] of Transaction::Sender
+    @db.query "select * from senders where transaction_id = ? order by idx", t.id do |rows|
+      rows.each do
+        rows.read(String?)
+        rows.read(Int64)
+        rows.read(Int32)
+        senders << {
+          address:    rows.read(String),
+          public_key: rows.read(String),
+          amount:     rows.read(Int64),
+          fee:        rows.read(Int64),
+          sign_r:     rows.read(String),
+          sign_s:     rows.read(String),
+        }
+      end
+    end
+    senders
+  end
+end

--- a/src/core/database/transactions.cr
+++ b/src/core/database/transactions.cr
@@ -1,0 +1,87 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+require "../blockchain/*"
+require "../blockchain/block/*"
+
+module ::Sushi::Core::Data::Transactions
+  # ------- Definition -------
+  def transaction_table_create_string
+    "id text, idx integer, block_id integer, action text, message text, token text, prev_hash text, timestamp integer, scaled integer, kind text"
+  end
+
+  def transaction_primary_key_string
+    "id, idx, block_id"
+  end
+
+  def transaction_insert_fields_string
+    "?, ?, ?, ?, ?, ?, ?, ?, ?, ?"
+  end
+
+  # ------- Insert -------
+  def transaction_insert_values_array(t : Transaction, transaction_idx : Int32, block_index : Int64) : Array(DB::Any)
+    ary = [] of DB::Any
+    ary << t.id << transaction_idx << block_index << t.action << t.message << t.token << t.prev_hash << t.timestamp << t.scaled << t.kind.to_s
+  end
+
+  # ------- Query -------
+  def get_all_transactions(block_index : Int64)
+    transactions_by_query(
+      "select * from transactions " \
+      "where block_id = ? " \
+      "order by idx asc",
+      block_index)
+  end
+
+  # ------- API -------
+  def get_paginated_transactions(block_index : Int64, page : Int32, per_page : Int32, direction : String)
+    page = page * per_page
+    transactions_by_query(
+      "select * from transactions " \
+      "where block_id = ? " \
+      "and oid not in ( select oid from transactions " \
+      "order by block_id #{direction} limit ? ) " \
+      "order by block_id #{direction} limit ?",
+      block_index, page, per_page)
+  end
+
+  # ------- Helpers -------
+  def transactions_by_query(query, *args)
+    transactions = [] of Transaction
+    verbose "Reading transactions from the database for block #{args}"
+    ti = 0
+    @db.query(query, args: args.to_a) do |rows|
+      rows.each do
+        t_id = rows.read(String)
+        rows.read(Int32)
+        rows.read(Int64)
+        action = rows.read(String)
+        message = rows.read(String)
+        token = rows.read(String)
+        prev_hash = rows.read(String)
+        timestamp = rows.read(Int64)
+        scaled = rows.read(Int32)
+        kind_string = rows.read(String)
+        kind = kind_string == "SLOW" ? TransactionKind::SLOW : TransactionKind::FAST
+
+        t = Transaction.new(t_id, action, [] of Transaction::Sender, [] of Transaction::Recipient, message, token, prev_hash, timestamp, scaled, kind)
+        transactions << t
+        verbose "reading transaction #{ti} from database with short ID of #{t.short_id}" if ti < 4
+        ti += 1
+      end
+    end
+    transactions.each do |t|
+      t.set_senders(get_senders(t))
+      t.set_recipients(get_recipients(t))
+    end
+    transactions
+  end
+end

--- a/src/core/database/transactions.cr
+++ b/src/core/database/transactions.cr
@@ -80,9 +80,9 @@ module ::Sushi::Core::Data::Transactions
       "(select oid from transactions order by token #{direction} limit ?) " \
       "order by token #{direction} limit ?",
       page, per_page) do |rows|
-        rows.each { res << rows.read(String) }
-      end
-      res
+      rows.each { res << rows.read(String) }
+    end
+    res
   end
 
   def token_exists?(token) : Bool
@@ -113,16 +113,16 @@ module ::Sushi::Core::Data::Transactions
       "join senders s on s.transaction_id = t.id " \
       "where action in ('scars_buy', 'scars_sell', 'scars_cancel') " \
       "and message = ?", domain_name) do |rows|
-        rows.each do 
-          domain_map[domain_name] = {
-            domain_name: rows.read(String),
-            address:     rows.read(String),
-            status:      status(rows.read(String)),
-            price:       rows.read(Int64)
-          }
-        end
+      rows.each do
+        domain_map[domain_name] = {
+          domain_name: rows.read(String),
+          address:     rows.read(String),
+          status:      status(rows.read(String)),
+          price:       rows.read(Int64),
+        }
       end
-      domain_map
+    end
+    domain_map
   end
 
   def get_domain_map_for_address(address : String) : DomainMap
@@ -133,28 +133,28 @@ module ::Sushi::Core::Data::Transactions
       "join senders s on s.transaction_id = t.id " \
       "where action in ('scars_buy', 'scars_sell', 'scars_cancel') " \
       "and address = ?", address) do |rows|
-        rows.each do 
-          domain_name = rows.read(String)
-          domain_map[domain_name] = {
-            domain_name: domain_name,
-            address:     rows.read(String),
-            status:      status(rows.read(String)),
-            price:       rows.read(Int64)
-          }
-        end
+      rows.each do
+        domain_name = rows.read(String)
+        domain_map[domain_name] = {
+          domain_name: domain_name,
+          address:     rows.read(String),
+          status:      status(rows.read(String)),
+          price:       rows.read(Int64),
+        }
       end
-      domain_map
+    end
+    domain_map
   end
- 
+
   def get_domains_for_sale : Array(Domain)
     domain_names = [] of String
     @db.query(
       "select distinct(message) from transactions where action = 'scars_sell'") do |rows|
-        rows.each do 
-           domain_names << rows.read(String)
-        end
+      rows.each do
+        domain_names << rows.read(String)
       end
-      domain_names.map{|n| get_domain_map_for(n)[n]? }.compact
+    end
+    domain_names.map { |n| get_domain_map_for(n)[n]? }.compact
   end
 
   private def status(action) : Status
@@ -164,7 +164,7 @@ module ::Sushi::Core::Data::Transactions
     when "scars_sell"
       Status::FOR_SALE
     else
-      Status::ACQUIRED  
+      Status::ACQUIRED
     end
   end
 
@@ -199,5 +199,6 @@ module ::Sushi::Core::Data::Transactions
     end
     transactions
   end
-include Sushi::Core::DApps::BuildIn
+
+  include Sushi::Core::DApps::BuildIn
 end

--- a/src/core/database/transactions.cr
+++ b/src/core/database/transactions.cr
@@ -69,6 +69,16 @@ module ::Sushi::Core::Data::Transactions
       page, per_page)
   end
 
+  def get_block_index_for_transaction(transaction_id : String) : Int64?
+    idx : Int64? = nil
+    @db.query("select block_id from transactions where id = ?", transaction_id) do |rows|
+      rows.each do
+        idx = rows.read(Int64 | Nil)
+      end
+    end
+    idx
+  end
+
   # ------- Helpers -------
   def transactions_by_query(query, *args)
     transactions = [] of Transaction

--- a/src/core/database/transactions.cr
+++ b/src/core/database/transactions.cr
@@ -125,6 +125,11 @@ module ::Sushi::Core::Data::Transactions
   # need to get the sales per domain - only domains that are currently for sale
   # and not ones that were for sale but now are in a different status
   # right now this query doesn't find the latest state for a domain so it's wrong
+
+  # maybe
+  # select id, t.block_id, message, address, amount, max(t.timestamp), action from transactions t
+  # join senders s on s.transaction_id = t.id
+  # where message in (select distinct(message) from transactions where action = 'scars_sell')  
   def get_domains_for_sale : Array(Domain)
     domains_for_sale = [] of Domain
     @db.query(

--- a/src/core/database/views.cr
+++ b/src/core/database/views.cr
@@ -13,9 +13,7 @@ require "../blockchain/*"
 require "../blockchain/block/*"
 
 module ::Sushi::Core
-    
   class Views
-    def initialize(@db : DB::Database) ; end
+    def initialize(@db : DB::Database); end
   end
-    
 end

--- a/src/core/database/views.cr
+++ b/src/core/database/views.cr
@@ -1,0 +1,21 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+require "../blockchain/*"
+require "../blockchain/block/*"
+
+module ::Sushi::Core
+    
+  class Views
+    def initialize(@db : DB::Database) ; end
+  end
+    
+end

--- a/src/core/node/components/api_params.cr
+++ b/src/core/node/components/api_params.cr
@@ -1,0 +1,37 @@
+# Copyright © 2017-2018 The SushiChain Core developers
+#
+# See the LICENSE file at the top-level directory of this distribution
+# for licensing information.
+#
+# Unless otherwise agreed in a custom licensing agreement with the SushiChain Core developers,
+# no part of this software, including this file, may be copied, modified,
+# propagated, or distributed except according to the terms contained in the
+# LICENSE file.
+#
+# Removal or modification of this copyright notice is prohibited.
+
+module ::Sushi::Core::NodeComponents
+  module APIParams
+    enum Direction
+      Up
+      Down
+
+      def to_s
+        case self
+        when Up
+          "asc"
+        else
+          "desc"
+        end
+      end
+    end
+
+    def paginated(query_params, page = 0, per_page = 20, direction = Direction::Up)
+      per_page = per_page > 100 ? 100 : per_page
+      [query_params["page"]?.try &.to_i || page,
+       query_params["per_page"]?.try &.to_i || per_page,
+       query_params["direction"]?.try{|d| d == "up" ? 0 : 1 } || direction.value
+      ]
+    end
+  end
+end

--- a/src/core/node/controllers/rest_controller.cr
+++ b/src/core/node/controllers/rest_controller.cr
@@ -95,14 +95,16 @@ module ::Sushi::Core::Controllers
     end
 
     def __v1_blockchain(context, params)
-      with_response(context) do
-        @blockchain.blockchain_info.blockchain_impl(false)
+      with_response(context) do |query_params|
+        page, per_page, direction = paginated(query_params)
+        @blockchain.blockchain_info.blockchain_impl(false, page, per_page, direction)
       end
     end
 
     def __v1_blockchain_header(context, params)
-      with_response(context) do
-        @blockchain.blockchain_info.blockchain_impl(true)
+      with_response(context) do |query_params|
+        page, per_page, direction = paginated(query_params)
+        @blockchain.blockchain_info.blockchain_impl(true, page, per_page, direction)
       end
     end
 
@@ -127,9 +129,10 @@ module ::Sushi::Core::Controllers
     end
 
     def __v1_block_index_transactions(context, params)
-      with_response(context) do
+      with_response(context) do |query_params|
         index = params["index"].to_i64
-        @blockchain.blockchain_info.transactions_impl(index)
+        page, per_page, direction = paginated(query_params)
+        @blockchain.blockchain_info.transactions_index_impl(index, page, per_page, direction)
       end
     end
 
@@ -199,7 +202,7 @@ module ::Sushi::Core::Controllers
         actions = query_params["actions"]?.try &.split(",") || [] of String
 
         address = params["address"]
-        @blockchain.blockchain_info.transactions_impl(address, page, page_size, actions)
+        @blockchain.blockchain_info.transactions_address_impl(address, page, page_size, actions)
       end
     end
 
@@ -229,7 +232,7 @@ module ::Sushi::Core::Controllers
 
         domain = params["domain"]
         address = convert_domain_to_address(domain, confirmation)
-        @blockchain.blockchain_info.transactions_impl(address, page, page_size, actions)
+        @blockchain.blockchain_info.transactions_address_impl(address, page, page_size, actions)
       end
     end
 
@@ -341,6 +344,7 @@ module ::Sushi::Core::Controllers
 
     include Router
     include NodeComponents::APIFormat
+    include NodeComponents::APIParams
     include TransactionModels
   end
 end

--- a/src/core/node/controllers/rest_controller.cr
+++ b/src/core/node/controllers/rest_controller.cr
@@ -117,14 +117,14 @@ module ::Sushi::Core::Controllers
     def __v1_block_index(context, params)
       with_response(context) do
         index = params["index"].to_i64
-        @blockchain.blockchain_info.block_impl(false, index)
+        @blockchain.blockchain_info.block_index_impl(false, index)
       end
     end
 
     def __v1_block_index_header(context, params)
       with_response(context) do
         index = params["index"].to_i64
-        @blockchain.blockchain_info.block_impl(true, index)
+        @blockchain.blockchain_info.block_index_impl(true, index)
       end
     end
 
@@ -146,14 +146,14 @@ module ::Sushi::Core::Controllers
     def __v1_transaction_id_block(context, params)
       with_response(context) do
         id = params["id"]
-        @blockchain.blockchain_info.block_impl(false, id)
+        @blockchain.blockchain_info.block_transaction_impl(false, id)
       end
     end
 
     def __v1_transaction_id_block_header(context, params)
       with_response(context) do
         id = params["id"]
-        @blockchain.blockchain_info.block_impl(true, id)
+        @blockchain.blockchain_info.block_transaction_impl(true, id)
       end
     end
 
@@ -197,12 +197,11 @@ module ::Sushi::Core::Controllers
 
     def __v1_address_transactions(context, params)
       with_response(context) do |query_params|
-        page = query_params["page"]?.try &.to_i || 0
-        page_size = query_params["page_size"]?.try &.to_i || 20
+        page, per_page, direction = paginated(query_params)
         actions = query_params["actions"]?.try &.split(",") || [] of String
-
         address = params["address"]
-        @blockchain.blockchain_info.transactions_address_impl(address, page, page_size, actions)
+
+        @blockchain.blockchain_info.transactions_address_impl(address, page, per_page, direction, actions)
       end
     end
 
@@ -225,14 +224,13 @@ module ::Sushi::Core::Controllers
 
     def __v1_domain_transactions(context, params)
       with_response(context) do |query_params|
-        page = query_params["page"]?.try &.to_i || 0
-        page_size = query_params["page_size"]?.try &.to_i || 20
+        page, per_page, direction = paginated(query_params)
         actions = query_params["actions"]?.try &.split(",") || [] of String
         confirmation = query_params["confirmation"]?.try &.to_i || 1
 
         domain = params["domain"]
         address = convert_domain_to_address(domain, confirmation)
-        @blockchain.blockchain_info.transactions_address_impl(address, page, page_size, actions)
+        @blockchain.blockchain_info.transactions_address_impl(address, page, per_page, direction, actions)
       end
     end
 

--- a/src/core/node/controllers/rest_controller.cr
+++ b/src/core/node/controllers/rest_controller.cr
@@ -277,8 +277,9 @@ module ::Sushi::Core::Controllers
     end
 
     def __v1_tokens(context, params)
-      with_response(context) do
-        @blockchain.token.tokens_list_impl
+      with_response(context) do |query_params|
+        page, per_page, direction = paginated(query_params)
+        @blockchain.token.tokens_list_impl(page, per_page, direction)
       end
     end
 


### PR DESCRIPTION
## Description
The following dApps now go straight to the db for data instead of using the in-memory chain. (This removes the need to record and clear the dApps constantly on every block refresh / sync)

- [x] blockchain_info 
- [x] indices
- [x] scars
- [x] token
- [] rejects
- [] utxo

In addition all the dApps that are used in the API have pagination 
