### PR TITLE
Reject fast transactions if the chain is not mature enough

### DIFF
--- a/spec/units/blockchain/fast_chain.cr
+++ b/spec/units/blockchain/fast_chain.cr
@@ -95,6 +95,19 @@ describe Blockchain do
     end
   end
 
+  describe "fast_transaction_maturity_check" do
+    it "should raise an exception if chain is not mature enough for fast transactions" do
+      with_factory do |block_factory, transaction_factory|
+        transaction1 = transaction_factory.make_fast_send(200000000_i64)
+        blockchain = block_factory.blockchain
+
+        block_factory.add_slow_blocks(2)
+        blockchain.add_transaction(transaction1, false)
+        blockchain.rejects.find(transaction1.id).should eq("chain not mature enough for FAST transactions")
+      end
+    end
+  end
+
   describe "valid_transactions_for_fast_block" do
     it "should the latest index and valid aligned transactions" do
       with_factory do |block_factory, transaction_factory|

--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -434,8 +434,12 @@ module ::Sushi::Core
     private def _add_transaction(transaction : Transaction)
       if transaction.valid_common?
         if transaction.kind == TransactionKind::FAST
-          debug "adding fast transaction to pool: #{transaction.id}"
-          FastTransactionPool.add(transaction) if chain_mature_enough_for_fast_blocks?
+          if !chain_mature_enough_for_fast_blocks?
+            raise "chain not mature enough for FAST transactions"
+          else
+            debug "adding fast transaction to pool: #{transaction.id}"
+            FastTransactionPool.add(transaction)
+          end
         else
           SlowTransactionPool.add(transaction)
         end


### PR DESCRIPTION
## Description
Added logic to reject fast transactions if the chain is not mature enough to accept them.

## Related Issues
https://github.com/SushiChain/SushiChain/issues/343
## Checklist
- [ x] All CI jobs finished successfully
