### PR TITLE
add hd wallet support

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -16,6 +16,10 @@ shards:
     github: crystal-lang/crystal-db
     version: 0.9.0
 
+  ed25519-hd:
+    github: sushichain/ed25519-hd
+    version: 0.1.0
+
   humanhash:
     github: kingsleyh/humanhash
     version: 0.1.2

--- a/shard.yml
+++ b/shard.yml
@@ -32,6 +32,8 @@ dependencies:
     github: sushichain/crystal-argon2
   monocypher:
     github: sushichain/monocypher.cr
+  ed25519-hd:
+    github: sushichain/ed25519-hd  
   i18n:
     github: TechMagister/i18n.cr
   baked_file_system:

--- a/spec/units/blockchain/blockchain.cr
+++ b/spec/units/blockchain/blockchain.cr
@@ -144,6 +144,45 @@ describe Blockchain do
       end
     end
 
+    it "should reject a transaction when trying to fake the sender" do
+      victim_wallet = Wallet.from_json(Wallet.create(true).to_json)
+      hacker_wallet = Wallet.from_json(Wallet.create(true).to_json)
+
+      sender = {address:    victim_wallet.address,
+                public_key: hacker_wallet.public_key,
+                amount:     10000000_i64,
+                fee:        10000000_i64,
+                signature:  "0",
+      }
+
+      recipient = {address: hacker_wallet.address,
+                   amount:  10000000_i64}
+
+      transaction_id = Transaction.create_id
+      unsigned_transaction = Transaction.new(
+        transaction_id,
+        "send", # action
+        [sender],
+        [recipient],
+        "0",   # message
+        "SUSHI", # token
+        "0",   # prev_hash
+        0_i64, # timestamp
+        1,     # scaled
+        TransactionKind::SLOW
+      )
+      transaction = unsigned_transaction.as_signed([hacker_wallet])
+
+      with_factory do |block_factory, transaction_factory|
+        block_factory.add_slow_block([transaction]).add_slow_blocks(2)
+        if reject = block_factory.blockchain.rejects.find(transaction.id)
+          reject.reason.should eq("sender public key mismatch - sender public key: #{hacker_wallet.public_key} is not for sender address: #{victim_wallet.address}")
+        else
+          fail "no rejects found"
+        end
+      end
+    end
+
     it "should reject a transaction if already present" do
       with_factory do |block_factory, transaction_factory|
         transaction = transaction_factory.make_send(200000000_i64)

--- a/spec/units/blockchain/blockchain.cr
+++ b/spec/units/blockchain/blockchain.cr
@@ -173,7 +173,7 @@ describe Blockchain do
       )
       transaction = unsigned_transaction.as_signed([hacker_wallet])
 
-      with_factory do |block_factory, transaction_factory|
+      with_factory do |block_factory, _|
         block_factory.add_slow_block([transaction]).add_slow_blocks(2)
         if reject = block_factory.blockchain.rejects.find(transaction.id)
           reject.reason.should eq("sender public key mismatch - sender public key: #{hacker_wallet.public_key} is not for sender address: #{victim_wallet.address}")

--- a/spec/units/keys/key_utils.cr
+++ b/spec/units/keys/key_utils.cr
@@ -33,4 +33,5 @@ describe KeyUtils do
 
     KeyUtils.verify_signature(message, signature_hex, hex_public_key).should be_true
   end
+
 end

--- a/spec/units/keys/keys.cr
+++ b/spec/units/keys/keys.cr
@@ -58,6 +58,58 @@ describe Keys do
     end
   end
 
+  describe "#KeyRing.generate_hd" do
+    it "should generate a random seed master keypair when no derivation and no seed supplied" do
+      keys = KeyRing.generate_hd
+
+      keys.private_key.should be_a(PrivateKey)
+      keys.private_key.as_hex.size.should eq(64)
+
+      keys.public_key.should be_a(PublicKey)
+      keys.public_key.as_hex.size.should eq(64)
+
+      keys.public_key.network.should eq(MAINNET)
+      keys.wif.network.should eq(MAINNET)
+      keys.address.network.should eq(MAINNET)
+
+      keys.seed.should_not be_nil
+    end
+
+    it "should generate a master keypair based on the supplied seed" do
+      seed = "000102030405060708090a0b0c0d0e0f"
+      keys = KeyRing.generate_hd(seed)
+
+      keys.private_key.as_hex.should eq("2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7")
+      keys.public_key.as_hex.should eq("a4b2856bfec510abab89753fac1ac0e1112364e7d250545963f135f2a33188ed")
+      keys.wif.as_hex.should eq("TTAyYjRiZTdmMTllZTI3YmJmMzBjNjY3YjY0MmQ1ZjRhYTY5ZmQxNjk4NzJmOGZjMzA1OWMwOGViYWUyZWIxOWU3Nzg4ZTA3")
+
+      keys.seed.should_not be_nil
+    end
+
+    it "should generate a child keypair based on the supplied seed" do
+      seed = "000102030405060708090a0b0c0d0e0f"
+      keys = KeyRing.generate_hd(seed, "m/0'")
+
+      keys.private_key.as_hex.should eq("433acfc3055954411068990af648eb8a24b85b40b76db87661592e4fda13fdc7")
+      keys.public_key.as_hex.should eq("883c44f8eb19e5ca570ab371c2cc6212b8099cb25c5fb0f66a3645a06069b836")
+      keys.wif.as_hex.should eq("TTA0MzNhY2ZjMzA1NTk1NDQxMTA2ODk5MGFmNjQ4ZWI4YTI0Yjg1YjQwYjc2ZGI4NzY2MTU5MmU0ZmRhMTNmZGM3MWU0MGVi")
+
+      keys.seed.should_not be_nil
+    end
+
+    it "should generate a child keypair based on a random seed" do
+      keys = KeyRing.generate_hd(nil, "m/0'")
+
+      keys.private_key.should be_a(PrivateKey)
+      keys.private_key.as_hex.size.should eq(64)
+
+      keys.public_key.should be_a(PublicKey)
+      keys.public_key.as_hex.size.should eq(64)
+
+      keys.seed.should_not be_nil
+    end
+  end
+
   describe "#KeyRing.is_valid?" do
     it "should return true when valid" do
       keys = KeyRing.generate(TESTNET)
@@ -83,5 +135,4 @@ describe Keys do
       end
     end
   end
-
 end

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -49,6 +49,8 @@ module ::Sushi::Interface
     @processes : Int32 = 1
 
     @encrypted : Bool = false
+    @seed : String?
+    @derivation : String?
 
     @price : String?
     @domain : String?
@@ -94,6 +96,8 @@ module ::Sushi::Interface
       PROCESSES
       # for wallet
       ENCRYPTED
+      SEED
+      DERIVATION
       # for scars
       PRICE
       DOMAIN
@@ -145,6 +149,8 @@ module ::Sushi::Interface
         parse_fast_transaction(parser, actives)
         parse_max_miners(parser, actives)
         parse_max_private_nodes(parser, actives)
+        parse_seed(parser, actives)
+        parse_derivation(parser, actives)
       end
     end
 
@@ -300,6 +306,18 @@ module ::Sushi::Interface
       parser.on("-e", "--encrypted", I18n.translate("cli.options.encrypted")) {
         @encrypted = true
       } if is_active?(actives, Options::ENCRYPTED)
+    end
+
+    private def parse_seed(parser : OptionParser, actives : Array(Options))
+      parser.on("--seed=SEED", I18n.translate("cli.options.seed")) { |seed|
+        @seed = seed
+      } if is_active?(actives, Options::SEED)
+    end
+
+    private def parse_derivation(parser : OptionParser, actives : Array(Options))
+      parser.on("--derivation=\"m/0'\"", I18n.translate("cli.options.derivation")) { |derivation|
+        @derivation = derivation
+      } if is_active?(actives, Options::DERIVATION)
     end
 
     private def parse_price(parser : OptionParser, actives : Array(Options))
@@ -466,6 +484,14 @@ module ::Sushi::Interface
       return @encrypted if @encrypted
       return cm.get_bool("encrypted", @config_name).not_nil! if cm.get_bool("encrypted", @config_name)
       @encrypted
+    end
+
+    def __seed : String?
+      @seed
+    end
+
+    def __derivation : String?
+      @derivation
     end
 
     def __price : String?

--- a/src/cli/sushi/wallet.cr
+++ b/src/cli/sushi/wallet.cr
@@ -44,11 +44,13 @@ module ::Sushi::Interface::Sushi
         Options::WALLET_PASSWORD,
         Options::IS_TESTNET,
         Options::ENCRYPTED,
+        Options::SEED,
+        Options::DERIVATION,
         Options::JSON,
         Options::ADDRESS,
         Options::DOMAIN,
         Options::TOKEN,
-        Options::CONFIG_NAME
+        Options::CONFIG_NAME,
       ])
     end
 
@@ -79,6 +81,13 @@ module ::Sushi::Interface::Sushi
       puts_help(HELP_WALLET_ALREADY_EXISTS % wallet_path) if File.exists?(wallet_path)
 
       wallet = Core::Wallet.from_json(Core::Wallet.create(G.op.__is_testnet).to_json)
+      seed = nil
+
+      if G.op.__seed || G.op.__derivation
+        hd = Core::Wallet.create_hd(G.op.__seed, G.op.__derivation, G.op.__is_testnet)
+        seed = hd[:seed]
+        wallet = Core::Wallet.from_json(hd[:wallet].to_json)
+      end
 
       if G.op.__encrypted
         puts_help(HELP_WALLET_PASSWORD) unless wallet_password = (G.op.__wallet_password || ENV["SC_WALLET_PASSWORD"]?)
@@ -95,6 +104,9 @@ module ::Sushi::Interface::Sushi
       else
         puts_success(I18n.translate("sushi.cli.wallet.create.messages.creation", {wallet_path: wallet_path}))
         puts_success(I18n.translate("sushi.cli.wallet.create.messages.backup"))
+      end
+      if seed
+        puts_success(I18n.translate("sushi.cli.wallet.create.messages.seed", {seed: seed.not_nil!}))
       end
     end
 

--- a/src/core.cr
+++ b/src/core.cr
@@ -29,6 +29,7 @@ require "openssl/digest"
 require "humanhash"
 require "crystal-argon2"
 require "monocypher"
+require "ed25519-hd"
 require "i18n"
 require "baked_file_system"
 

--- a/src/core/blockchain/transaction.cr
+++ b/src/core/blockchain/transaction.cr
@@ -123,6 +123,10 @@ module ::Sushi::Core
         network = Keys::Address.from(sender[:address], "sender").network
         public_key = Keys::PublicKey.new(sender[:public_key], network)
 
+        if public_key.address.as_hex != sender[:address]
+          raise "sender public key mismatch - sender public key: #{public_key.as_hex} is not for sender address: #{sender[:address]}"
+        end
+
         verbose "unsigned_json: #{self.as_unsigned.to_json}"
         verbose "unsigned_json_hash: #{self.as_unsigned.to_hash}"
         verbose "public key: #{public_key.as_hex}"
@@ -185,7 +189,6 @@ module ::Sushi::Core
       signed_senders = self.senders.map_with_index { |s, i|
         private_key = Wif.new(wallets[i].wif).private_key
 
-        # sign = ECCrypto.sign(private_key.as_hex, self.to_hash)
         signature = KeyUtils.sign(private_key.as_hex, self.to_hash)
 
         {

--- a/src/core/blockchain/wallet.cr
+++ b/src/core/blockchain/wallet.cr
@@ -70,6 +70,17 @@ module ::Sushi::Core
       }
     end
 
+    def self.create_hd(seed = nil, derivation = nil, testnet = false)
+      network = testnet ? TESTNET : MAINNET
+      keys = KeyRing.generate_hd(seed, derivation, network)
+      seed = keys.seed
+      {wallet: {
+        public_key: keys.public_key.as_hex,
+        wif:        keys.wif.as_hex,
+        address:    keys.address.as_hex,
+      }, seed: seed}
+    end
+
     def self.verify!(public_key : String, wif : String, address : String) : Bool
       KeyRing.is_valid?(public_key, wif, address)
     end

--- a/src/locales/options_parser/en.yml
+++ b/src/locales/options_parser/en.yml
@@ -28,6 +28,8 @@ cli:
     headers:      "get headers only when get a blockchain or blocks"
     processes:    "# of the work processes (default is 1)"
     encrypted:    "set this flag when creating a wallet to create an encrypted wallet"
+    seed:         "generate an hd wallet from a seed (master keypair if --derivation not speficied)"
+    derivation:   "generate an hd wallet at the specified derivation path (random seed if --seed not specified, use 'm' for master)"
     scars:
       price:      "buy/sell price for SCARS"
       domain:     "specify a domain for SCARS"

--- a/src/locales/sushi/en.yml
+++ b/src/locales/sushi/en.yml
@@ -10,6 +10,7 @@ sushi:
         messages:
           creation: "your new wallet has been created at %{wallet_path}"
           backup:   "please make a backup of the json file and keep it secret."
+          seed:     "Your wallet was generated with this seed: %{seed} (please keep it very safe)"
       verify:
         title:      "verify"
         desc:       "verify a wallet file"


### PR DESCRIPTION
This PR adds:

* ability to generate a master keypair from a supplied seed or a random seed
* ability to generate a child keypair from a supplied seed or a random seed

e.g. 

* master keypair from supplied seed or random seed

```bash
sushi wallet create --seed=some_seed --derivation=m
sushi wallet create --derivation=m
```

* child keypairs from supplied seed or random seed

```bash
sushi wallet create --seed=some_seed --derivation=m/0
sushi wallet create --derivation=m/0
```

Notes:

This implementation is based on [slip-0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md#slip-0010--universal-private-key-derivation-from-master-private-key) which supports only **private key derivation** and not public key derivation. For this reason all derivation paths are hardened.

The official path notation has been implemented but the *hardened* symbol `'`  is optional since all paths use hardened. e.g.

```
m/0' 
m/0

m/0'/1'/2'
m/0/1/2
```

